### PR TITLE
Fix the CSP_NOTIFY setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,11 @@ Or either ``inline-script`` or ``eval-script`` can be enabled separately.
 Report URI
 ----------
 
-Content Security Policy allows you to specify a URI that accepts violation
-reports. Django-CSP includes a view that accepts these reports and forwards
-them via email to the list of people specified in the ``CSP_NOTIFY`` setting.
+Content Security Policy allows you to specify a URI that accepts
+violation reports. Django-CSP includes a view that accepts these
+reports and forwards them via email to the list of people specified in
+the ``CSP_NOTIFY`` setting (or the project admins if ``CSP_NOTIFY`` is
+not set).
 
 To accept violation reports, you need only add the following to your site's
 ``urls.py``::

--- a/csp/views.py
+++ b/csp/views.py
@@ -1,6 +1,7 @@
 import json
 
-from django.core.mail import mail_admins
+from django.conf import settings
+from django.core.mail import mail_admins, send_mail
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.template import loader, Context
 from django.views.decorators.http import require_POST
@@ -33,7 +34,10 @@ def report(request):
 
     subject = 'CSP Violation: %s: %s' % (data['blocked_uri'],
                                          data['violated_directive'])
-    mail_admins(subject, body)
+    if hasattr(settings, 'CSP_NOTIFY'):
+        send_mail(subject, body, settings.SERVER_EMAIL, settings.CSP_NOTIFY)
+    else:
+        mail_admins(subject, body)
     return HttpResponse()
 
 


### PR DESCRIPTION
As documented, the `CSP_NOTIFY` setting is a list of recipient addresses for CSP violation reports. This setting currently does nothing. This patch implements this functionality, and retains the current fallback to django admins if `CSP_NOTIFY` is not set.
