### PR TITLE
Add CSP_EXCLUDE_URL_PREFXIES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,12 @@ The following settings take only a URI, not a tuple::
     CSP_REPORT_URI
     CSP_POLICY_URI
 
+You can disable CSP for specific url prefixes with the
+``CSP_EXCLUDE_URL_PREFIXES`` setting. For example, to exclude the django admin
+(which uses inline Javascript) with the standard urlconf::
+
+    CSP_EXCLUDE_URL_PREFIXES = ('/admin',)
+
 
 The Options Directive
 ^^^^^^^^^^^^^^^^^^^^^

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -17,6 +17,11 @@ class CSPMiddleware(object):
         if getattr(response, '_csp_exempt', False):
             return response
 
+        # Check for ignored path prefix.
+        for prefix in getattr(settings, 'CSP_EXCLUDE_URL_PREFIXES', []):
+            if request.path_info.startswith(prefix):
+                return response
+
         header = 'X-Content-Security-Policy'
         if getattr(settings, 'CSP_REPORT_ONLY', False):
             header = 'X-Content-Security-Policy-Report-Only'


### PR DESCRIPTION
CSP_EXCLUDE_URL_PREFIXES allows users to specify certain URLs that
should not send CSP headers in their responses.

fixes #4
