### PR TITLE
Remove exception handling from csp.views.report

### DIFF
--- a/csp/views.py
+++ b/csp/views.py
@@ -19,11 +19,8 @@ def report(request):
 
     """
 
-    try:
-        violation = request.raw_post_data
-        Report.create(violation).save(RequestSite(request))
-    except Exception:
-        return HttpResponseBadRequest()
+    violation = request.raw_post_data
+    Report.create(violation).save(RequestSite(request))
 
     return HttpResponse()
 


### PR DESCRIPTION
There is no need to catch all Exceptions and return an HttpResponseBadRequest() because django does this by default.

All this does is make debug more difficult.
