### PR TITLE
Update for CSP "Last Call Working Draft"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ The Settings
 ------------
 
 These settings take a tuple of values. For simplicity, the special values
-``'self'`` and ``'none'`` must contain the single quotes. See the spec for
-allowed use of the ``*`` wildcard::
+``'self'``, ``'unsafe-inline'``, and ``'unsafe-eval'`` must contain
+the single quotes. See the spec for allowed use of the ``*`` wildcard::
 
     CSP_DEFAULT_SRC
     CSP_IMG_SRC
@@ -51,8 +51,8 @@ allowed use of the ``*`` wildcard::
     CSP_MEDIA_SRC
     CSP_FRAME_SRC
     CSP_FONT_SRC
-    CSP_XHR_SRC
-    CSP_FRAME_ANCESTORS
+    CSP_CONNECT_SRC
+    CSP_SANDBOX
 
 The following settings take only a URI, not a tuple::
 
@@ -63,20 +63,6 @@ You can disable CSP for specific url prefixes with the
 (which uses inline Javascript) with the standard urlconf::
 
     CSP_EXCLUDE_URL_PREFIXES = ('/admin',)
-
-
-The Options Directive
-^^^^^^^^^^^^^^^^^^^^^
-
-Content Security Policy defines an ``options`` directive that allows you to
-re-enable inline scripts, ``javascript:`` URIs and ``eval()``, all disabled
-by default when CSP is active.
-
-To re-enable both, for example, use the ``CSP_OPTIONS`` setting, a tuple::
-
-    CSP_OPTIONS = ('disable-xss-protection', 'eval-script')
-
-Or either ``disable-xss-protection`` or ``eval-script`` can be enabled separately.
 
 
 Report URI

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -10,8 +10,6 @@ def build_policy():
     policy = ['default-src %s' % (' '.join(settings.CSP_DEFAULT_SRC) if
                             hasattr(settings, 'CSP_DEFAULT_SRC') else
                             "'self'")]
-    if hasattr(settings, 'CSP_OPTIONS'):
-        policy.append('options %s' % ' '.join(settings.CSP_OPTIONS))
     if hasattr(settings, 'CSP_IMG_SRC'):
         policy.append('img-src %s' % ' '.join(settings.CSP_IMG_SRC))
     if hasattr(settings, 'CSP_SCRIPT_SRC'):
@@ -24,13 +22,12 @@ def build_policy():
         policy.append('frame-src %s' % ' '.join(settings.CSP_FRAME_SRC))
     if hasattr(settings, 'CSP_FONT_SRC'):
         policy.append('font-src %s' % ' '.join(settings.CSP_FONT_SRC))
-    if hasattr(settings, 'CSP_XHR_SRC'):
-        policy.append('xhr-src %s' % ' '.join(settings.CSP_XHR_SRC))
+    if hasattr(settings, 'CSP_CONNECT_SRC'):
+        policy.append('connect-src %s' % ' '.join(settings.CSP_CONNECT_SRC))
     if hasattr(settings, 'CSP_STYLE_SRC'):
         policy.append('style-src %s' % ' '.join(settings.CSP_STYLE_SRC))
-    if hasattr(settings, 'CSP_FRAME_ANCESTORS'):
-        policy.append('frame-ancestors %s' %
-                      ' '.join(settings.CSP_FRAME_ANCESTORS))
+    if hasattr(settings, 'CSP_SANDBOX'):
+        policy.append('sandbox %s' % ' '.join(settings.CSP_SANDBOX))
     if hasattr(settings, 'CSP_REPORT_URI'):
         policy.append('report-uri %s' % settings.CSP_REPORT_URI)
 


### PR DESCRIPTION
These changes include fmarier's pull request 2, "Update the middleware for Draft 20110315", and updates django-csp to match the "Last Call Working Draft": http://www.w3.org/TR/2012/WD-CSP-20120710/

I haven't tested violation reports extensively.  Neither Firefox Aurora 15.0a2 nor Chrome 20.0.1132.57 send compliant violation reports.
