### PR TITLE
set headers from settings.CSP_HEADERS #8

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -29,6 +29,6 @@ class CSPMiddleware(object):
             if getattr(settings, 'CSP_REPORT_ONLY', False):
                 header = header + '-Report-Only'
             
-            response[header] = response.get(header, policy)
+            response.setdefault(header,policy)
 
         return response


### PR DESCRIPTION
A potential solution to #8 rather than worrying about what header to send, let the user decide in CSP_HEADERS
