### PR TITLE
inform setup.py of templates it needs to copy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['example']),
     include_package_data=True,
+    package_data={
+        'csp': ['templates/csp/email/*'],
+    },
+    zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
setup.py needs to know about package resources, so they can be copied into the installation environment.
