### PR TITLE
Changes blocked_uri field to a models.CharField.

### DIFF
--- a/csp/models.py
+++ b/csp/models.py
@@ -47,7 +47,7 @@ class Report(models.Model):
     """A representation of one report."""
     group = models.ForeignKey(Group, null=True, blank=True)
     document_uri = models.URLField(max_length=400, db_index=True)
-    blocked_uri = models.URLField(max_length=400, null=True, blank=True,
+    blocked_uri = models.CharField(max_length=400, null=True, blank=True,
                                   db_index=True)
     referrer = models.URLField(max_length=400, null=True, blank=True)
     violated_directive = models.CharField(max_length=1000, null=True,


### PR DESCRIPTION
The blocked-uri parameter from CSP reports does not have to be an absolute URL.

Django's URLField is too restrictive for what should be allowable for the browser to send for the `blocked-uri` value.
