### PR TITLE
Remove deprecated X- prefix for CSP header

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -6,7 +6,7 @@ from csp.utils import build_policy
 
 class CSPMiddleware(object):
     """
-    Implements the X-Content-Security-Policy response header, which
+    Implements the Content-Security-Policy response header, which
     conforming user-agents can use to restrict the permitted sources
     of various content.
 
@@ -25,7 +25,7 @@ class CSPMiddleware(object):
 
         ua = request.META.get('HTTP_USER_AGENT', '')
         webkit = 'webkit' in ua.lower()
-        header = 'X-WebKit-CSP' if webkit else 'X-Content-Security-Policy'
+        header = 'X-WebKit-CSP' if webkit else 'Content-Security-Policy'
         if getattr(settings, 'CSP_REPORT_ONLY', False):
             header += '-Report-Only'
 

--- a/csp/tests.py
+++ b/csp/tests.py
@@ -46,7 +46,7 @@ def test_webkit_header():
             if is_webkit:
                 assert ('X-WebKit-CSP' + suffix) in response, response
             else:
-                assert ('X-Content-Security-Policy' + suffix) in response, ua
+                assert ('Content-Security-Policy' + suffix) in response, ua
             assert 'User-Agent' in response['Vary']
         return _test
 


### PR DESCRIPTION
Maybe should not merge yet until Firefox 15+ gains greater adoption, but gets rid of that annoying message on the Firefox developer console.
