### PR TITLE
Remove deprecated headers

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -23,9 +23,7 @@ class CSPMiddleware(object):
         if request.path_info.startswith(prefixes):
             return response
 
-        ua = request.META.get('HTTP_USER_AGENT', '')
-        webkit = 'webkit' in ua.lower()
-        header = 'X-WebKit-CSP' if webkit else 'X-Content-Security-Policy'
+        header = 'Content-Security-Policy'
         if getattr(settings, 'CSP_REPORT_ONLY', False):
             header += '-Report-Only'
 

--- a/csp/tests.py
+++ b/csp/tests.py
@@ -14,7 +14,7 @@ def test_empty_policy():
 
 
 def test_webkit_header():
-    """If the browser looks like WebKit, send X-WebKit-CSP."""
+    """Content-Security-Policy headers should be sent back to agents."""
     request = RequestFactory().get('/')
     mw = CSPMiddleware()
 
@@ -43,10 +43,7 @@ def test_webkit_header():
             request.META['HTTP_USER_AGENT'] = ua
             response = HttpResponse()
             mw.process_response(request, response)
-            if is_webkit:
-                assert ('X-WebKit-CSP' + suffix) in response, response
-            else:
-                assert ('X-Content-Security-Policy' + suffix) in response, ua
+            assert ('Content-Security-Policy' + suffix) in response, ua
             assert 'User-Agent' in response['Vary']
         return _test
 


### PR DESCRIPTION
Should only be using the standard `Content-Security-Policy` header now.

Modern browsers won't even read the deprecated headers anymore.
