### PR TITLE
add warning for csp exceptions

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,11 +74,11 @@ These settings control the behavior of django-csp. Defaults are in
 
 .. warning::
 
-   Excluding a path on your website might kill all the CSP benefits for
-   good. The typical browser security model for JavaScript considers all
-   paths alike. A Cross-Site Scripting flaw on, e.g., `admin/` can be
-   leveraged to access everything on the same origin.
-
+   Excluding any path on your site will eliminate the benefits of CSP
+   everywhere on your site. The typical browser security model for
+   JavaScript considers all paths alike. A Cross-Site Scripting flaw
+   on, e.g., `admin/` can therefore be leveraged to access everything
+   on the same origin.
 
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/
 .. _spec: Content-Security-Policy_


### PR DESCRIPTION
I found it notable to point out that XSS on one path gives DOM/XMLHttpRequest access to all other paths.
CSP exceptions sound like a bad idea to me, but might still be justifiable on secure subpages which underwent a higher level of scrutiny.

I hope this is valid sphinx syntax and shows a warning box. My knowledge in this area is limited.. :)
If this warning text sounds too harsh or could need different wording, feel free to change.
