### PR TITLE
Add possibility for transmitting the X-WebKit-CSP header (issue #33).

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -28,8 +28,10 @@ class CSPMiddleware(object):
         if status_code == http_client.INTERNAL_SERVER_ERROR and settings.DEBUG:
             return response
 
+        webkit_legacy_header = 'X-WebKit-CSP'
         header = 'Content-Security-Policy'
         if getattr(settings, 'CSP_REPORT_ONLY', False):
+            webkit_legacy_header += '-Report-Only'
             header += '-Report-Only'
 
         if header in response:
@@ -39,6 +41,8 @@ class CSPMiddleware(object):
         config = getattr(response, '_csp_config', None)
         update = getattr(response, '_csp_update', None)
         replace = getattr(response, '_csp_replace', None)
-        response[header] = build_policy(config=config, update=update,
-                                        replace=replace)
+        policy = build_policy(config=config, update=update, replace=replace)
+        response[header] = policy
+        if getattr(settings, 'CSP_WEBKIT_LEGACY', False):
+            response[webkit_legacy_header] = policy
         return response

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -8,6 +8,7 @@ from csp.middleware import CSPMiddleware
 
 
 HEADER = 'Content-Security-Policy'
+WEBKIT_LEGACY_HEADER = 'X-WebKit-CSP'
 mw = CSPMiddleware()
 rf = RequestFactory()
 
@@ -75,3 +76,21 @@ class MiddlewareTests(TestCase):
         response = HttpResponseServerError()
         mw.process_response(request, response)
         assert HEADER not in response
+
+    @override_settings(CSP_WEBKIT_LEGACY=True)
+    def test_webkit_legacy_header(self):
+        request = rf.get('/')
+        response = HttpResponse()
+        mw.process_response(request, response)
+        assert HEADER in response
+        assert WEBKIT_LEGACY_HEADER in response
+
+    @override_settings(CSP_REPORT_ONLY=True, CSP_WEBKIT_LEGACY=True)
+    def test_webkit_legacy_report_only(self):
+        request = rf.get('/')
+        response = HttpResponse()
+        mw.process_response(request, response)
+        assert HEADER not in response
+        assert WEBKIT_LEGACY_HEADER not in response
+        assert HEADER + '-Report-Only' in response
+        assert WEBKIT_LEGACY_HEADER + '-Report-Only' in response

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -94,3 +94,10 @@ class MiddlewareTests(TestCase):
         assert WEBKIT_LEGACY_HEADER not in response
         assert HEADER + '-Report-Only' in response
         assert WEBKIT_LEGACY_HEADER + '-Report-Only' in response
+
+    def test_webkit_legacy_default_off(self):
+        request = rf.get('/')
+        response = HttpResponse()
+        mw.process_response(request, response)
+        assert WEBKIT_LEGACY_HEADER not in response
+        assert WEBKIT_LEGACY_HEADER + 'Report-Only' not in response


### PR DESCRIPTION
Proposed implementation of issue #33. I left out the detection of Safari, since this is quite unreliable on the server-side using the user-agent string. If this fix looks good to you, I'll send a pull request updating the documentation.