### PR TITLE
Changed middleware to try and get the Django admin URL dynamically

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.six.moves import http_client
 
 from csp.utils import build_policy
@@ -19,7 +20,14 @@ class CSPMiddleware(object):
             return response
 
         # Check for ignored path prefix.
-        prefixes = getattr(settings, 'CSP_EXCLUDE_URL_PREFIXES', ('/admin',))
+        prefixes = getattr(settings, 'CSP_EXCLUDE_URL_PREFIXES', None)
+        if prefixes is None:
+            # try and get the correct path for the Django admin
+            try:
+                prefixes = (reverse('admin:index'),)
+            except NoReverseMatch:
+                prefixes = ()
+
         if request.path_info.startswith(prefixes):
             return response
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -22,3 +22,5 @@ INSTALLED_APPS = (
 )
 
 SECRET_KEY = 'csp-test-key'
+
+ROOT_URLCONF = 'test_urlconf'

--- a/test_urlconf.py
+++ b/test_urlconf.py
@@ -1,0 +1,6 @@
+from django.conf.urls import patterns, url, include
+from django.contrib import admin
+
+urlpatterns = patterns("",
+    url(r'django_admin/', include(admin.site.urls)),
+)


### PR DESCRIPTION
Pull request for #44. All tests pass, which is highly suspicious, because I've not added or modified any, and I feel like `MiddlewareTests.text_exclude` *should* fail, but I can't even get a `import pdb; pdb.set_trace()` breakpoint working when invoking `./run.sh test`, so it's actually kind of impossible for me to tell if my fix ... is a fix. 