### PR TITLE
CSP_DEFAULT_SRC default to None

### DIFF
--- a/csp/utils.py
+++ b/csp/utils.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 def from_settings():
     return {
-        'default-src': getattr(settings, 'CSP_DEFAULT_SRC', ["'self'"]),
+        'default-src': getattr(settings, 'CSP_DEFAULT_SRC', None),
         'script-src': getattr(settings, 'CSP_SCRIPT_SRC', None),
         'object-src': getattr(settings, 'CSP_OBJECT_SRC', None),
         'style-src': getattr(settings, 'CSP_STYLE_SRC', None),


### PR DESCRIPTION
This PR is mostly for the discussion to make sure we're setting the default like it is on purpose.

According to [the docs](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/CSP_policy_directives) for default-src:

> The default-src directive defines the security policy for all types of content which are not expressly called out by more specific directives.

Defaulting to 'self' would be a good idea if every site was intent on enforcing every directive.  However, there are many directives and I think it's more reasonable to expect a site to enforce, say, script-src and style-src and ignore the rest.  With this default in place they can't ignore the rest, as the rest are suddenly set to 'self' instead of None.

It's easily avoided by setting CSP_DEFAULT_SRC = None in your config, but I just wanted to double check that it's the best default we can make.

I came across this because getting CSP to work for every directive can be a lot of work so we've been focused on incremental steps.  I defined script-src and object-srcs and then got a flood of reports about style-src which I hadn't touched at all - then I realized it had a default.

Anyway.  Thoughts?
