### PR TITLE
Fix some of the interlinks in the docs.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -57,7 +57,7 @@ Changing the Policy
 -------------------
 
 The policy can be changed on a per-view (or even per-request) basis. See
-the `decorator documentation <decorator-chapter>`_ for more details.
+the :ref:`decorator documentation <decorator-chapter>` for more details.
 
 
 Other Settings
@@ -68,7 +68,7 @@ These settings control the behavior of django-csp. Defaults are in
 
 ``CSP_REPORT_ONLY``
     Send "report-only" headers instead of real headers. See the spec_
-    and the chapter on `reports <reports-chapter>`_ for more info. A
+    and the chapter on :ref:`reports <reports-chapter>` for more info. A
     boolean. *False*
 ``CSP_EXCLUDE_URL_PREFIXES``
     A **tuple** of URL prefixes. URLs beginning with any of these will

--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -48,8 +48,8 @@ passed to the decorator will be used verbatim.
 
     default-src 'self'; img-src imgsrv.com
 
-The arguments to the decorator the same as the `settings
-<configuration-chapter>`_ without the ``CSP_`` prefix, e.g. ``IMG_SRC``.
+The arguments to the decorator the same as the :ref:`settings
+<configuration-chapter>` without the ``CSP_`` prefix, e.g. ``IMG_SRC``.
 (They are also case-insensitive.) The values are either strings, lists
 or tuples.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,4 +25,4 @@ built in report processor, all you need to do is::
         # ...
     )
 
-That should do it! Go on to `configuring CSP <configuration-chapter>`_.
+That should do it! Go on to :ref:`configuring CSP <configuration-chapter>`.


### PR DESCRIPTION
I noticed a few broken links on [Read the Docs](http://django-csp.readthedocs.org/en/latest/index.html). This pull request fixes it (at least locally when building with Sphinx).