### PR TITLE
Django admin doesn't use inline JS anymore

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -19,7 +19,7 @@ class CSPMiddleware(object):
             return response
 
         # Check for ignored path prefix.
-        prefixes = getattr(settings, 'CSP_EXCLUDE_URL_PREFIXES', ('/admin',))
+        prefixes = getattr(settings, 'CSP_EXCLUDE_URL_PREFIXES', ())
         if request.path_info.startswith(prefixes):
             return response
 

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -26,8 +26,9 @@ class MiddlewareTests(TestCase):
         mw.process_response(request, response)
         assert HEADER not in response
 
+    @override_settings(CSP_EXCLUDE_URL_PREFIXES=('/inlines-r-us'))
     def text_exclude(self):
-        request = rf.get('/admin/foo')
+        request = rf.get('/inlines-r-us/foo')
         response = HttpResponse()
         mw.process_response(request, response)
         assert HEADER not in response

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -72,14 +72,14 @@ These settings control the behavior of django-csp. Defaults are in
     boolean. *False*
 ``CSP_EXCLUDE_URL_PREFIXES``
     A **tuple** of URL prefixes. URLs beginning with any of these will
-    not get the CSP headers. *('/admin',)*
+    not get the CSP headers. *()*
 
 .. warning::
 
    Excluding any path on your site will eliminate the benefits of CSP
    everywhere on your site. The typical browser security model for
    JavaScript considers all paths alike. A Cross-Site Scripting flaw
-   on, e.g., `admin/` can therefore be leveraged to access everything
+   on, e.g., `excluded-page/` can therefore be leveraged to access everything
    on the same origin.
 
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/


### PR DESCRIPTION
Once https://github.com/django/django/pull/5567/ lands Django admin will support django-csp out of the box