### PR TITLE
Fix bug when @csp arguments were strings

### DIFF
--- a/csp/decorators.py
+++ b/csp/decorators.py
@@ -37,7 +37,11 @@ def csp_replace(**kwargs):
 
 
 def csp(**kwargs):
-    config = dict((k.lower().replace('_', '-'), v) for k, v in kwargs.items())
+    config = dict(
+        (k.lower().replace('_', '-'), [v] if isinstance(v, str) else v)
+        for k, v
+        in kwargs.items()
+    )
 
     def decorator(f):
         @wraps(f)

--- a/csp/tests/test_decorators.py
+++ b/csp/tests/test_decorators.py
@@ -5,10 +5,10 @@ from django.test.utils import override_settings
 from nose.tools import eq_
 
 from csp.decorators import csp, csp_replace, csp_update, csp_exempt
-
+from csp.middleware import CSPMiddleware
 
 REQUEST = RequestFactory().get('/')
-
+mw = CSPMiddleware()
 
 class DecoratorTests(TestCase):
     def test_csp_exempt(self):
@@ -35,9 +35,23 @@ class DecoratorTests(TestCase):
         eq_(response._csp_replace, {'img-src': 'bar.com'})
 
     def test_csp(self):
+        @csp(IMG_SRC=['foo.com'], FONT_SRC=['bar.com'])
+        def view(request):
+            return HttpResponse()
+        response = view(REQUEST)
+        eq_(response._csp_config,
+            {'img-src': ['foo.com'], 'font-src': ['bar.com']})
+        mw.process_response(REQUEST, response)
+        eq_(policy_list, ["font-src bar.com", "img-src foo.com"])
+
+    def test_csp_string_values(self):
+        # Test backwards compatibility where values were strings
         @csp(IMG_SRC='foo.com', FONT_SRC='bar.com')
         def view(request):
             return HttpResponse()
         response = view(REQUEST)
         eq_(response._csp_config,
-            {'img-src': 'foo.com', 'font-src': 'bar.com'})
+            {'img-src': ['foo.com'], 'font-src': ['bar.com']})
+        mw.process_response(REQUEST, response)
+        policy_list = sorted(response['Content-Security-Policy'].split("; "))
+        eq_(policy_list, ["font-src bar.com", "img-src foo.com"])

--- a/csp/tests/test_decorators.py
+++ b/csp/tests/test_decorators.py
@@ -42,6 +42,7 @@ class DecoratorTests(TestCase):
         eq_(response._csp_config,
             {'img-src': ['foo.com'], 'font-src': ['bar.com']})
         mw.process_response(REQUEST, response)
+        policy_list = sorted(response['Content-Security-Policy'].split("; "))
         eq_(policy_list, ["font-src bar.com", "img-src foo.com"])
 
     def test_csp_string_values(self):

--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -90,7 +90,7 @@ are as above::
 
     from csp.decorators import csp
 
-    @csp(DEFAULT_SRC="'self'", IMG_SRC='imgsrv.com',
+    @csp(DEFAULT_SRC=["'self'"], IMG_SRC=['imgsrv.com'],
          SCRIPT_SRC=['scriptsrv.com', 'googleanalytics.com'])
     def myview(request):
         return render(...)


### PR DESCRIPTION
The bug was causing this code:

    @csp(IMG_SRC='imgsrv2.com')
    def view(request):
         # ....

to emit headers like `Content-Security-Policy: img-src i m g s r v 2 . c o m`

I fixed the bug, and I changed the documentation to instruct users to use lists or tuples for consistency
with the configuration.
