### PR TITLE
Accidental config mutating bug

### DIFF
--- a/csp/tests/test_decorators.py
+++ b/csp/tests/test_decorators.py
@@ -20,46 +20,84 @@ def test_csp_exempt():
 
 @override_settings(CSP_IMG_SRC=['foo.com'])
 def test_csp_update():
-    @csp_update(IMG_SRC='bar.com')
-    def view(request):
+    def view_without_decorator(request):
         return HttpResponse()
-    response = view(REQUEST)
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src foo.com"]
+
+    @csp_update(IMG_SRC='bar.com')
+    def view_with_decorator(request):
+        return HttpResponse()
+    response = view_with_decorator(REQUEST)
     assert response._csp_update == {'img-src': 'bar.com'}
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src foo.com bar.com"]
+
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src foo.com"]
 
 
 @override_settings(CSP_IMG_SRC=['foo.com'])
 def test_csp_replace():
-    @csp_replace(IMG_SRC='bar.com')
-    def view(request):
+    def view_without_decorator(request):
         return HttpResponse()
-    response = view(REQUEST)
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src foo.com"]
+
+    @csp_replace(IMG_SRC='bar.com')
+    def view_with_decorator(request):
+        return HttpResponse()
+    response = view_with_decorator(REQUEST)
     assert response._csp_replace == {'img-src': 'bar.com'}
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src bar.com"]
+
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'", "img-src foo.com"]
 
 
 def test_csp():
-    @csp(IMG_SRC=['foo.com'], FONT_SRC=['bar.com'])
-    def view(request):
+    def view_without_decorator(request):
         return HttpResponse()
-    response = view(REQUEST)
-    assert response._csp_config == {
-        'img-src': ['foo.com'], 'font-src': ['bar.com']
-    }
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'"]
 
+    @csp(IMG_SRC=['foo.com'], FONT_SRC=['bar.com'])
+    def view_with_decorator(request):
+        return HttpResponse()
+    response = view_with_decorator(REQUEST)
+    assert response._csp_config == \
+        {'img-src': ['foo.com'], 'font-src': ['bar.com']}
     mw.process_response(REQUEST, response)
     policy_list = sorted(response['Content-Security-Policy'].split("; "))
     assert policy_list == ["font-src bar.com", "img-src foo.com"]
+
+    response = view_without_decorator(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response['Content-Security-Policy'].split("; "))
+    assert policy_list == ["default-src 'self'"]
 
 
 def test_csp_string_values():
     # Test backwards compatibility where values were strings
     @csp(IMG_SRC='foo.com', FONT_SRC='bar.com')
-    def view(request):
+    def view_with_decorator(request):
         return HttpResponse()
-    response = view(REQUEST)
-    assert response._csp_config == {
-        'img-src': ['foo.com'], 'font-src': ['bar.com']
-    }
-
+    response = view_with_decorator(REQUEST)
+    assert response._csp_config == \
+        {'img-src': ['foo.com'], 'font-src': ['bar.com']}
     mw.process_response(REQUEST, response)
     policy_list = sorted(response['Content-Security-Policy'].split("; "))
     assert policy_list == ["font-src bar.com", "img-src foo.com"]

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -72,7 +72,8 @@ def test_use_replace():
     response = HttpResponse()
     response._csp_replace = {'img-src': ['bar.com']}
     mw.process_response(request, response)
-    assert response[HEADER] == "default-src 'self'; img-src bar.com"
+    policy_list = sorted(response[HEADER].split('; '))
+    assert policy_list == ["default-src 'self'", "img-src bar.com"]
 
 
 @override_settings(DEBUG=True)


### PR DESCRIPTION
The decorators would accidentally mutate config, causing future requests against other views to return the wrong policy.
    
This fixes that, and it includes tests. This builds upon code in pull request #51 , so merging this will merge both.
