### PR TITLE
Allow lazy-evaluated string objects (such as reverse_lazy) to be assi…

### DIFF
--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,4 +1,6 @@
 from django.test.utils import override_settings
+from django.utils.functional import lazy
+from django.utils import six
 
 from csp.utils import build_policy
 
@@ -12,6 +14,13 @@ def policy_eq(a, b, msg='%r != %r'):
 def test_empty_policy():
     policy = build_policy()
     assert "default-src 'self'" == policy
+
+
+def literal(s):
+    return s
+
+
+lazy_literal = lazy(literal, six.text_type)
 
 
 @override_settings(CSP_DEFAULT_SRC=['example.com', 'example2.com'])
@@ -82,6 +91,12 @@ def test_sandbox_empty():
 
 @override_settings(CSP_REPORT_URI='/foo')
 def test_report_uri():
+    policy = build_policy()
+    policy_eq("default-src 'self'; report-uri /foo", policy)
+
+
+@override_settings(CSP_REPORT_URI=lazy_literal('/foo'))
+def test_report_uri_lazy():
     policy = build_policy()
     policy_eq("default-src 'self'; report-uri /foo", policy)
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.encoding import force_text
 import copy
 from itertools import chain
 
@@ -55,5 +56,6 @@ def build_policy(config=None, update=None, replace=None):
     policy = ['%s %s' % (kk, ' '.join(vv)) for kk, vv in
               csp.items() if vv is not None]
     if report_uri:
+        report_uri = map(force_text, report_uri)
         policy.append('report-uri %s' % ' '.join(report_uri))
     return '; '.join(policy)


### PR DESCRIPTION
…gned to CSP_REPORT_URI

Fixes #67 