### PR TITLE
Add support for django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - pypy
 
 env:
+  - DJANGO_VERSION=1.10.x
   - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
   - DJANGO_VERSION=1.7.x

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,10 +1,20 @@
 from django.conf import settings
 from django.utils.six.moves import http_client
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    class MiddlewareMixin(object):
+        """
+        If this middleware doesn't exist, this is an older version of django
+        and we don't need it.
+        """
+        pass
+
 from csp.utils import build_policy
 
 
-class CSPMiddleware(object):
+class CSPMiddleware(MiddlewareMixin):
     """
     Implements the Content-Security-Policy response header, which
     conforming user-agents can use to restrict the permitted sources

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
 deps19 =
     https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
+deps110 =
+    https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
 
 
 [testenv:2.7-1.6.x]
@@ -38,6 +40,11 @@ basepython = python2.7
 deps =
     {[testenv]deps19}
 
+[testenv:2.7-1.10.x]
+basepython = python2.7
+deps =
+    {[testenv]deps110}
+
 [testenv:3.4-1.6.x]
 basepython = python3.4
 deps =
@@ -58,6 +65,11 @@ basepython = python3.4
 deps =
     {[testenv]deps19}
 
+[testenv:3.4-1.10.x]
+basepython = python3.4
+deps =
+    {[testenv]deps110}
+
 [testenv:3.5-1.8.x]
 basepython = python3.5
 deps =
@@ -67,6 +79,11 @@ deps =
 basepython = python3.5
 deps =
     {[testenv]deps19}
+
+[testenv:3.5-1.10.x]
+basepython = python3.5
+deps =
+    {[testenv]deps110}
 
 [testenv:pypy-1.6.x]
 basepython = pypy
@@ -87,3 +104,8 @@ deps =
 basepython = pypy
 deps =
     {[testenv]deps19}
+
+[testenv:pypy-1.10.x]
+basepython = pypy
+deps =
+    {[testenv]deps110}


### PR DESCRIPTION
This PR does two things:

- It adds django 1.10 to the build environment for python 2.7, 3.4, 3.5, and pypy
- It uses the [django.utils.deprecation.MiddlewareMixin](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#django.utils.deprecation.MiddlewareMixin) to make the `CSPMiddleware` compatible with the [new](https://docs.djangoproject.com/en/1.10/topics/http/middleware/) and old middleware style.

This PR will resolve #70 

Thoughts? I would love some feedback. 😄 