### PR TITLE
Add missing directives

### DIFF
--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -193,3 +193,9 @@ def test_worker_src():
 def test_plugin_types():
     policy = build_policy()
     policy_eq("default-src 'self'; plugin-types application/pdf", policy)
+
+
+@override_settings(CSP_REQUIRE_SRI_FOR=['script'])
+def test_require_sri_for():
+    policy = build_policy()
+    policy_eq("default-src 'self'; require-sri-for script", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -199,3 +199,9 @@ def test_plugin_types():
 def test_require_sri_for():
     policy = build_policy()
     policy_eq("default-src 'self'; require-sri-for script", policy)
+
+
+@override_settings(CSP_UPGRADE_INSECURE_REQUESTS=True)
+def test_upgrade_insecure_requests():
+    policy = build_policy()
+    policy_eq("default-src 'self'; upgrade-insecure-requests ", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -187,3 +187,9 @@ def test_manifest_src():
 def test_worker_src():
     policy = build_policy()
     policy_eq("default-src 'self'; worker-src example.com", policy)
+
+
+@override_settings(CSP_PLUGIN_TYPES=['application/pdf'])
+def test_plugin_types():
+    policy = build_policy()
+    policy_eq("default-src 'self'; plugin-types application/pdf", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -175,3 +175,9 @@ def test_child_src():
 def test_frame_ancestors():
     policy = build_policy()
     policy_eq("default-src 'self'; frame-ancestors example.com", policy)
+
+
+@override_settings(CSP_MANIFEST_SRC=['example.com'])
+def test_manifest_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; manifest-src example.com", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -205,3 +205,9 @@ def test_require_sri_for():
 def test_upgrade_insecure_requests():
     policy = build_policy()
     policy_eq("default-src 'self'; upgrade-insecure-requests ", policy)
+
+
+@override_settings(CSP_BLOCK_ALL_MIXED_CONTENT=True)
+def test_block_all_mixed_content():
+    policy = build_policy()
+    policy_eq("default-src 'self'; block-all-mixed-content ", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -181,3 +181,9 @@ def test_frame_ancestors():
 def test_manifest_src():
     policy = build_policy()
     policy_eq("default-src 'self'; manifest-src example.com", policy)
+
+
+@override_settings(CSP_WORKER_SRC=['example.com'])
+def test_worker_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; worker-src example.com", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -204,10 +204,10 @@ def test_require_sri_for():
 @override_settings(CSP_UPGRADE_INSECURE_REQUESTS=True)
 def test_upgrade_insecure_requests():
     policy = build_policy()
-    policy_eq("default-src 'self'; upgrade-insecure-requests ", policy)
+    policy_eq("default-src 'self'; upgrade-insecure-requests", policy)
 
 
 @override_settings(CSP_BLOCK_ALL_MIXED_CONTENT=True)
 def test_block_all_mixed_content():
     policy = build_policy()
-    policy_eq("default-src 'self'; block-all-mixed-content ", policy)
+    policy_eq("default-src 'self'; block-all-mixed-content", policy)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -24,6 +24,7 @@ def from_settings():
         'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
         'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
         'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
+        'require-sri-for': getattr(settings, 'CSP_REQUIRE_SRI_FOR', None),
     }
 
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -25,6 +25,8 @@ def from_settings():
         'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
         'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
         'require-sri-for': getattr(settings, 'CSP_REQUIRE_SRI_FOR', None),
+        'upgrade-insecure-requests': getattr(
+            settings, 'CSP_UPGRADE_INSECURE_REQUESTS', None),
     }
 
 
@@ -57,9 +59,16 @@ def build_policy(config=None, update=None, replace=None):
                 csp[k] += tuple(v)
 
     report_uri = csp.pop('report-uri', None)
+    upgrade_insecure_requests = csp.pop('upgrade-insecure-requests', None)
+
     policy = ['%s %s' % (kk, ' '.join(vv)) for kk, vv in
               csp.items() if vv is not None]
+
     if report_uri:
         report_uri = map(force_text, report_uri)
         policy.append('report-uri %s' % ' '.join(report_uri))
+
+    if upgrade_insecure_requests:
+        policy.append('upgrade-insecure-requests ')
+
     return '; '.join(policy)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -23,6 +23,7 @@ def from_settings():
         'frame-ancestors': getattr(settings, 'CSP_FRAME_ANCESTORS', None),
         'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
         'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
+        'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
     }
 
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -27,6 +27,8 @@ def from_settings():
         'require-sri-for': getattr(settings, 'CSP_REQUIRE_SRI_FOR', None),
         'upgrade-insecure-requests': getattr(
             settings, 'CSP_UPGRADE_INSECURE_REQUESTS', None),
+        'block-all-mixed-content': getattr(
+            settings, 'CSP_BLOCK_ALL_MIXED_CONTENT', None),
     }
 
 
@@ -60,6 +62,7 @@ def build_policy(config=None, update=None, replace=None):
 
     report_uri = csp.pop('report-uri', None)
     upgrade_insecure_requests = csp.pop('upgrade-insecure-requests', None)
+    block_all_mixed_content = csp.pop('block-all-mixed-content', None)
 
     policy = ['%s %s' % (kk, ' '.join(vv)) for kk, vv in
               csp.items() if vv is not None]
@@ -70,5 +73,8 @@ def build_policy(config=None, update=None, replace=None):
 
     if upgrade_insecure_requests:
         policy.append('upgrade-insecure-requests ')
+
+    if block_all_mixed_content:
+        policy.append('block-all-mixed-content ')
 
     return '; '.join(policy)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -21,6 +21,7 @@ def from_settings():
         'child-src': getattr(settings, 'CSP_CHILD_SRC', None),
         'form-action': getattr(settings, 'CSP_FORM_ACTION', None),
         'frame-ancestors': getattr(settings, 'CSP_FRAME_ANCESTORS', None),
+        'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
     }
 
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -22,6 +22,7 @@ def from_settings():
         'form-action': getattr(settings, 'CSP_FORM_ACTION', None),
         'frame-ancestors': getattr(settings, 'CSP_FRAME_ANCESTORS', None),
         'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
+        'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
     }
 
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -26,9 +26,9 @@ def from_settings():
         'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
         'require-sri-for': getattr(settings, 'CSP_REQUIRE_SRI_FOR', None),
         'upgrade-insecure-requests': getattr(
-            settings, 'CSP_UPGRADE_INSECURE_REQUESTS', None),
+            settings, 'CSP_UPGRADE_INSECURE_REQUESTS', False),
         'block-all-mixed-content': getattr(
-            settings, 'CSP_BLOCK_ALL_MIXED_CONTENT', None),
+            settings, 'CSP_BLOCK_ALL_MIXED_CONTENT', False),
     }
 
 
@@ -61,20 +61,19 @@ def build_policy(config=None, update=None, replace=None):
                 csp[k] += tuple(v)
 
     report_uri = csp.pop('report-uri', None)
-    upgrade_insecure_requests = csp.pop('upgrade-insecure-requests', None)
-    block_all_mixed_content = csp.pop('block-all-mixed-content', None)
 
-    policy = ['%s %s' % (kk, ' '.join(vv)) for kk, vv in
-              csp.items() if vv is not None]
+    policy_parts = []
+    for key, value in csp.items():
+        # flag directives with an empty directive value
+        if len(value) and value[0] is True:
+            policy_parts.append(key)
+        elif len(value) and value[0] is False:
+            pass
+        else:  # directives with many values like src lists
+            policy_parts.append('%s %s' % (key, ' '.join(value)))
 
     if report_uri:
         report_uri = map(force_text, report_uri)
-        policy.append('report-uri %s' % ' '.join(report_uri))
+        policy_parts.append('report-uri %s' % ' '.join(report_uri))
 
-    if upgrade_insecure_requests:
-        policy.append('upgrade-insecure-requests ')
-
-    if block_all_mixed_content:
-        policy.append('block-all-mixed-content ')
-
-    return '; '.join(policy)
+    return '; '.join(policy_parts)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,6 +66,8 @@ These settings affect the policy in the header. The defaults are in
     Note: This doesn't use default-src as a fall-back.
 ``CSP_MANIFEST_SRC``
     Set the ``manifest-src`` directive. A tuple or list. *None*
+``CSP_WOKER_SRC``
+    Set the ``worker-src`` directive. A tuple or list. *None*
 
 
 Changing the Policy

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,10 +76,10 @@ These settings affect the policy in the header. The defaults are in
     Valid values: ``script``, ``style``, or both. See: require-sri-for-known-tokens_
     Note: This doesn't use default-src as a fall-back.
 ``CSP_UPGRADE_INSECURE_REQUESTS``
-    Include ``upgrade-insecure-requests`` directive. A boolean. *None*
+    Include ``upgrade-insecure-requests`` directive. A boolean. *False*
     See: upgrade-insecure-requests_
 ``CSP_UPGRADE_INSECURE_REQUESTS``
-    Include ``block-all-mixed-content`` directive. A boolean. *None*
+    Include ``block-all-mixed-content`` directive. A boolean. *False*
     See: block-all-mixed-content_
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,6 +64,8 @@ These settings affect the policy in the header. The defaults are in
     Set the ``report-uri`` directive. A **string** with a full or
     relative URI.
     Note: This doesn't use default-src as a fall-back.
+``CSP_MANIFEST_SRC``
+    Set the ``manifest-src`` directive. A tuple or list. *None*
 
 
 Changing the Policy

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -75,6 +75,9 @@ These settings affect the policy in the header. The defaults are in
     Set the ``require-sri-for`` directive. A tuple or list. *None*
     Valid values: ``script``, ``style``, or both. See: require-sri-for-known-tokens_
     Note: This doesn't use default-src as a fall-back.
+``CSP_UPGRADE_INSECURE_REQUESTS``
+    Include ``upgrade-insecure-requests`` directive. A boolean. *None*
+    See: upgrade-insecure-requests_
 
 
 Changing the Policy
@@ -109,3 +112,4 @@ These settings control the behavior of django-csp. Defaults are in
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/
 .. _spec: Content-Security-Policy_
 .. _require-sri-for-known-tokens: https://w3c.github.io/webappsec-subresource-integrity/#opt-in-require-sri-for
+.. _upgrade-insecure-requests: https://w3c.github.io/webappsec-upgrade-insecure-requests/#delivery

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,6 +68,9 @@ These settings affect the policy in the header. The defaults are in
     Set the ``manifest-src`` directive. A tuple or list. *None*
 ``CSP_WOKER_SRC``
     Set the ``worker-src`` directive. A tuple or list. *None*
+``CSP_PLUGIN_TYPES``
+    Set the ``plugin-types`` directive. A tuple or list. *None*
+    Note: This doesn't use default-src as a fall-back.
 
 
 Changing the Policy

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -78,6 +78,9 @@ These settings affect the policy in the header. The defaults are in
 ``CSP_UPGRADE_INSECURE_REQUESTS``
     Include ``upgrade-insecure-requests`` directive. A boolean. *None*
     See: upgrade-insecure-requests_
+``CSP_UPGRADE_INSECURE_REQUESTS``
+    Include ``block-all-mixed-content`` directive. A boolean. *None*
+    See: block-all-mixed-content_
 
 
 Changing the Policy
@@ -113,3 +116,4 @@ These settings control the behavior of django-csp. Defaults are in
 .. _spec: Content-Security-Policy_
 .. _require-sri-for-known-tokens: https://w3c.github.io/webappsec-subresource-integrity/#opt-in-require-sri-for
 .. _upgrade-insecure-requests: https://w3c.github.io/webappsec-upgrade-insecure-requests/#delivery
+.. _block-all-mixed-content: https://w3c.github.io/webappsec-mixed-content/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,6 +71,10 @@ These settings affect the policy in the header. The defaults are in
 ``CSP_PLUGIN_TYPES``
     Set the ``plugin-types`` directive. A tuple or list. *None*
     Note: This doesn't use default-src as a fall-back.
+``CSP_REQUIRE_SRI_FOR``
+    Set the ``require-sri-for`` directive. A tuple or list. *None*
+    Valid values: ``script``, ``style``, or both. See: require-sri-for-known-tokens_
+    Note: This doesn't use default-src as a fall-back.
 
 
 Changing the Policy
@@ -104,3 +108,4 @@ These settings control the behavior of django-csp. Defaults are in
 
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/
 .. _spec: Content-Security-Policy_
+.. _require-sri-for-known-tokens: https://w3c.github.io/webappsec-subresource-integrity/#opt-in-require-sri-for


### PR DESCRIPTION
Adds the following CSP directives:

* manifest-src https://github.com/mozilla/django-csp/issues/60
* worker-src
* plugin-types https://github.com/mozilla/django-csp/issues/59
* require-sri-for
* upgrade-insecure-requests https://github.com/mozilla/django-csp/issues/58
* block-all-mixed-content

Is this package tracking CSP drafts, shipped CSP directives, or both?

require-sri-for, upgrade-insecure-requests, block-all-mixed-content, and the CSP 3 headers are still in draft.  There is a tiny overhead to including them, but we gain forward compatibility assuming they stay in the specs.

On the other hand, referrer-policy https://github.com/mozilla/django-csp/issues/57 and reflected-xss were removed from CSP, but adding them could still benefit users at the cost of some historical baggage.