### PR TITLE
Add basic nonce implementation to build_policy and CSPMiddleware

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -27,7 +27,8 @@ class CSPMiddleware(MiddlewareMixin):
 
     """
     def _make_nonce(self, request, length=16):
-        # Return cached value if this has been executed already
+        # Ensure that any subsequent calls to request.csp_nonce return the
+        # same value
         if not getattr(request, '_csp_nonce', None):
             request._csp_nonce = get_random_string(length)
         return request._csp_nonce

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from django.conf import settings
 from django.utils.crypto import get_random_string
+from django.utils.functional import SimpleLazyObject
 from django.utils.six.moves import http_client
 
 try:
@@ -34,7 +35,8 @@ class CSPMiddleware(MiddlewareMixin):
         return request._csp_nonce
 
     def process_request(self, request):
-        request.csp_nonce = partial(self._make_nonce, request)
+        nonce = partial(self._make_nonce, request)
+        request.csp_nonce = SimpleLazyObject(nonce)
 
     def process_response(self, request, response):
         if getattr(response, '_csp_exempt', False):

--- a/csp/tests/settings.py
+++ b/csp/tests/settings.py
@@ -1,5 +1,6 @@
 CSP_REPORT_ONLY = False
-CSP_DISABLE_NONCE = False
+
+CSP_INCLUDE_NONCE_IN = ['default-src']
 
 DATABASES = {
     'default': {

--- a/csp/tests/settings.py
+++ b/csp/tests/settings.py
@@ -1,4 +1,5 @@
 CSP_REPORT_ONLY = False
+CSP_DISABLE_NONCE = False
 
 DATABASES = {
     'default': {

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -118,7 +118,7 @@ def test_nonce_regenerated_on_new_request():
     assert nonce2 not in response1[HEADER]
 
 
-@override_settings(CSP_DISABLE_NONCE=True)
+@override_settings(CSP_INCLUDE_NONCE_IN=[])
 def test_no_nonce_when_disabled_by_settings():
     request = rf.get('/')
     mw.process_request(request)

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -116,3 +116,13 @@ def test_nonce_regenerated_on_new_request():
     mw.process_response(request2, response2)
     assert nonce1 not in response2[HEADER]
     assert nonce2 not in response1[HEADER]
+
+
+@override_settings(CSP_DISABLE_NONCE=True)
+def test_no_nonce_when_disabled_by_settings():
+    request = rf.get('/')
+    mw.process_request(request)
+    nonce = request.csp_nonce()
+    response = HttpResponse()
+    mw.process_response(request, response)
+    assert nonce not in response[HEADER]

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -87,7 +87,7 @@ def test_debug_exempt():
 def test_nonce_created_when_accessed():
     request = rf.get('/')
     mw.process_request(request)
-    nonce = request.csp_nonce()
+    nonce = str(request.csp_nonce)
     response = HttpResponse()
     mw.process_response(request, response)
     assert nonce in response[HEADER]
@@ -106,9 +106,9 @@ def test_nonce_regenerated_on_new_request():
     request2 = rf.get('/')
     mw.process_request(request1)
     mw.process_request(request2)
-    nonce1 = request1.csp_nonce()
-    nonce2 = request2.csp_nonce()
-    assert request1.csp_nonce() != request2.csp_nonce()
+    nonce1 = str(request1.csp_nonce)
+    nonce2 = str(request2.csp_nonce)
+    assert request1.csp_nonce != request2.csp_nonce
 
     response1 = HttpResponse()
     response2 = HttpResponse()
@@ -122,7 +122,7 @@ def test_nonce_regenerated_on_new_request():
 def test_no_nonce_when_disabled_by_settings():
     request = rf.get('/')
     mw.process_request(request)
-    nonce = request.csp_nonce()
+    nonce = str(request.csp_nonce)
     response = HttpResponse()
     mw.process_response(request, response)
     assert nonce not in response[HEADER]

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -82,3 +82,37 @@ def test_debug_exempt():
     response = HttpResponseServerError()
     mw.process_response(request, response)
     assert HEADER not in response
+
+
+def test_nonce_created_when_accessed():
+    request = rf.get('/')
+    mw.process_request(request)
+    nonce = request.csp_nonce()
+    response = HttpResponse()
+    mw.process_response(request, response)
+    assert nonce in response[HEADER]
+
+
+def test_no_nonce_when_not_accessed():
+    request = rf.get('/')
+    mw.process_request(request)
+    response = HttpResponse()
+    mw.process_response(request, response)
+    assert 'nonce-' not in response[HEADER]
+
+
+def test_nonce_regenerated_on_new_request():
+    request1 = rf.get('/')
+    request2 = rf.get('/')
+    mw.process_request(request1)
+    mw.process_request(request2)
+    nonce1 = request1.csp_nonce()
+    nonce2 = request2.csp_nonce()
+    assert request1.csp_nonce() != request2.csp_nonce()
+
+    response1 = HttpResponse()
+    response2 = HttpResponse()
+    mw.process_response(request1, response1)
+    mw.process_response(request2, response2)
+    assert nonce1 not in response2[HEADER]
+    assert nonce2 not in response1[HEADER]

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -211,3 +211,8 @@ def test_upgrade_insecure_requests():
 def test_block_all_mixed_content():
     policy = build_policy()
     policy_eq("default-src 'self'; block-all-mixed-content", policy)
+
+
+def test_nonce():
+    policy = build_policy(nonce='abc123')
+    policy_eq("default-src 'self'; nonce-abc123", policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -86,7 +86,7 @@ def test_sandbox():
 @override_settings(CSP_SANDBOX=[])
 def test_sandbox_empty():
     policy = build_policy()
-    policy_eq("default-src 'self'; sandbox ", policy)
+    policy_eq("default-src 'self'; sandbox", policy)
 
 
 @override_settings(CSP_REPORT_URI='/foo')
@@ -215,4 +215,12 @@ def test_block_all_mixed_content():
 
 def test_nonce():
     policy = build_policy(nonce='abc123')
-    policy_eq("default-src 'self'; nonce-abc123", policy)
+    policy_eq("default-src 'self' nonce-abc123", policy)
+
+
+@override_settings(CSP_INCLUDE_NONCE_IN=['script-src', 'style-src'])
+def test_nonce_include_in():
+    policy = build_policy(nonce='abc123')
+    policy_eq(("default-src 'self'; "
+               "script-src nonce-abc123; "
+               "style-src nonce-abc123"), policy)

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -215,12 +215,12 @@ def test_block_all_mixed_content():
 
 def test_nonce():
     policy = build_policy(nonce='abc123')
-    policy_eq("default-src 'self' nonce-abc123", policy)
+    policy_eq("default-src 'self' 'nonce-abc123'", policy)
 
 
 @override_settings(CSP_INCLUDE_NONCE_IN=['script-src', 'style-src'])
 def test_nonce_include_in():
     policy = build_policy(nonce='abc123')
     policy_eq(("default-src 'self'; "
-               "script-src nonce-abc123; "
-               "style-src nonce-abc123"), policy)
+               "script-src 'nonce-abc123'; "
+               "style-src 'nonce-abc123'"), policy)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -32,7 +32,7 @@ def from_settings():
     }
 
 
-def build_policy(config=None, update=None, replace=None):
+def build_policy(config=None, update=None, replace=None, nonce=None):
     """Builds the policy as a string from the settings."""
 
     if config is None:
@@ -75,5 +75,8 @@ def build_policy(config=None, update=None, replace=None):
     if report_uri:
         report_uri = map(force_text, report_uri)
         policy_parts.append('report-uri %s' % ' '.join(report_uri))
+
+    if nonce:
+        policy_parts.append('nonce-%s' % nonce)
 
     return '; '.join(policy_parts)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -80,7 +80,7 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
         for section in settings.CSP_INCLUDE_NONCE_IN:
             policy = policy_parts.get(section, '')
             policy_parts[section] = ("%s %s" %
-                                     (policy, "nonce-%s" % nonce)).strip()
+                                     (policy, "'nonce-%s'" % nonce)).strip()
 
     return '; '.join(['{} {}'.format(k, val).strip()
                       for k, val in policy_parts.items()])

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -82,5 +82,5 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
             policy_parts[section] = ("%s %s" %
                                      (policy, "nonce-%s" % nonce)).strip()
 
-    return '; '.join(['{} {}'.format(k, v).strip()
-                      for k, v in policy_parts.items()])
+    return '; '.join(['{} {}'.format(k, val).strip()
+                      for k, val in policy_parts.items()])

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -76,7 +76,7 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
         report_uri = map(force_text, report_uri)
         policy_parts.append('report-uri %s' % ' '.join(report_uri))
 
-    if nonce:
+    if nonce and not getattr(settings, 'CSP_DISABLE_NONCE', False):
         policy_parts.append('nonce-%s' % nonce)
 
     return '; '.join(policy_parts)


### PR DESCRIPTION
RE: https://github.com/mozilla/django-csp/issues/48

Add the groundwork for nonce generation to `build_policy` and `CSPMiddleware`. If the interest still primarily lies in a new template tag I would be glad to add that (as well as a simple context processor) in a follow-up PR.

Also of note: my initial pass of the nonce generation function was something like `b64encode(os.urandom(16))` and I won't push back if someone would prefer something more specific, but it seemed easier to lean on the django crypto utils.