### PR TITLE
"Safe" script template tag

### DIFF
--- a/csp/extensions/__init__.py
+++ b/csp/extensions/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from jinja2 import nodes
+from jinja2.ext import Extension
+
+from csp.utils import SCRIPT_ATTRS, build_script_tag
+
+
+class NoncedScript(Extension):
+    # a set of names that trigger the extension.
+    tags = set(['script'])
+
+    def parse(self, parser):
+        # the first token is the token that started the tag.  In our case
+        # we only listen to ``'script'`` so this will be a name token with
+        # `script` as value.  We get the line number so that we can give
+        # that line number to the nodes we create by hand.
+        lineno = next(parser.stream).lineno
+
+        # Get the current context and pass along
+        kwargs = [nodes.Keyword('ctx', nodes.ContextReference())]
+
+        # Parse until we are done with optional script tag attributes
+        while parser.stream.current.value in SCRIPT_ATTRS:
+            attr_name = parser.stream.current.value
+            parser.stream.skip(2)
+            kwargs.append(
+                nodes.Keyword(attr_name, parser.parse_expression()))
+
+        # now we parse the body of the script block up to `endscript` and
+        # drop the needle (which would always be `endscript` in that case)
+        body = parser.parse_statements(['name:endscript'], drop_needle=True)
+
+        # now return a `CallBlock` node that calls our _render_script
+        # helper method on this extension.
+        return nodes.CallBlock(
+            self.call_method('_render_script', kwargs=kwargs),
+            [], [], body).set_lineno(lineno)
+
+    def _render_script(self, caller, **kwargs):
+        ctx = kwargs.pop('ctx')
+        request = ctx.get('request')
+        kwargs['nonce'] = request.csp_nonce
+        kwargs['content'] = caller().strip()
+
+        return build_script_tag(**kwargs)

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from functools import partial
 
 from django.conf import settings

--- a/csp/templatetags/csp.py
+++ b/csp/templatetags/csp.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from django import template
+from django.template.base import token_kwargs
+
+from csp.utils import build_script_tag
+
+register = template.Library()
+
+
+def _unquote(s):
+    """Helper func that strips single and double quotes from inside strings"""
+    return s.replace('"', '').replace("'", "")
+
+
+@register.tag(name='script')
+def script(parser, token):
+    # Parse out any keyword args
+    token_args = token.split_contents()
+    kwargs = token_kwargs(token_args[1:], parser)
+
+    nodelist = parser.parse(('endscript',))
+    parser.delete_first_token()
+
+    return NonceScriptNode(nodelist, **kwargs)
+
+
+class NonceScriptNode(template.Node):
+    def __init__(self, nodelist, **kwargs):
+        self.nodelist = nodelist
+        self.script_attrs = {}
+        for k, v in kwargs.items():
+            self.script_attrs[k] = self._get_token_value(v)
+
+    def _get_token_value(self, t):
+        return _unquote(t.token) if getattr(t, 'token', None) else None
+
+    def render(self, context):
+        output = self.nodelist.render(context).strip()
+        request = context.get('request')
+        nonce = request.csp_nonce if hasattr(request, 'csp_nonce') else ''
+        self.script_attrs.update({'nonce': nonce, 'content': output})
+
+        return build_script_tag(**self.script_attrs)

--- a/csp/tests/environment.py
+++ b/csp/tests/environment.py
@@ -1,0 +1,6 @@
+from jinja2 import Environment
+
+
+def environment(**options):
+    env = Environment(**options)
+    return env

--- a/csp/tests/settings.py
+++ b/csp/tests/settings.py
@@ -1,3 +1,6 @@
+import django
+
+
 CSP_REPORT_ONLY = False
 
 CSP_INCLUDE_NONCE_IN = ['default-src']
@@ -19,3 +22,26 @@ INSTALLED_APPS = (
 )
 
 SECRET_KEY = 'csp-test-key'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'environment': 'csp.tests.environment.environment',
+            'extensions': ['csp.extensions.NoncedScript']
+            },
+    },
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {},
+    },
+]
+
+
+# Django >1.6 requires `setup` call to initialise apps framework
+if hasattr(django, 'setup'):
+    django.setup()

--- a/csp/tests/test_jinja_extension.py
+++ b/csp/tests/test_jinja_extension.py
@@ -1,0 +1,79 @@
+from csp.tests.utils import ScriptExtensionTestBase
+
+
+class TestJinjaExtension(ScriptExtensionTestBase):
+
+    def test_script_tag_injects_nonce(self):
+        tpl = """
+            {% script %}
+                var hello='world';
+            {% endscript %}
+        """
+
+        expected = ("""<script nonce="{}">var hello='world';</script>""")
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_script_with_src_ignores_body(self):
+        tpl = """
+            {% script src="foo" %}
+                var hello='world';
+            {% endscript %}
+        """
+
+        expected = """<script nonce="{}" src="foo"></script>"""
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_script_tag_sets_attrs_correctly(self):
+        tpl = """
+            {% script id='jeff' defer=True %}
+                var hello='world';
+            {% endscript %}
+            """
+        expected = """
+            <script nonce="{}" id="jeff" defer>
+                var hello='world';
+            </script>"""
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_async_attribute_with_falsey(self):
+        tpl = """
+            {% script id="jeff" async=False %}
+                var hello='world';
+            {% endscript %}"""
+
+        expected = ('<script nonce="{}" id="jeff" async=false>'
+                    'var hello=\'world\';'
+                    '</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_async_attribute_with_truthy(self):
+        tpl = """
+            {% script id="jeff" async=True %}
+                var hello='world';
+            {% endscript %}"""
+
+        expected = ('<script nonce="{}" id="jeff" async>'
+                    'var hello=\'world\';'
+                    '</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_nested_script_tags_are_removed(self):
+        """Let users wrap their code in script tags for the sake of their
+           development environment"""
+        tpl = """
+            {% script type="application/javascript" id="jeff" defer=True%}
+                <script type="text/javascript">
+                var hello='world';
+                </script>
+            {% endscript %}"""
+
+        expected = (
+            '<script'
+            ' nonce="{}" id="jeff" type="application/javascript" defer>'
+            'var hello=\'world\';</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))

--- a/csp/tests/test_templatetags.py
+++ b/csp/tests/test_templatetags.py
@@ -1,0 +1,78 @@
+from csp.tests.utils import ScriptTagTestBase
+
+
+class TestDjangoTemplateTag(ScriptTagTestBase):
+
+    def test_script_tag_injects_nonce(self):
+        tpl = """
+            {% load csp %}
+            {% script %}var hello='world';{% endscript %}"""
+
+        expected = """<script nonce="{}">var hello='world';</script>"""
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_script_with_src_ignores_body(self):
+        tpl = ("""
+            {% load csp %}
+            {% script src="foo" %}
+                var hello='world';
+            {% endscript %}""")
+
+        expected = """<script nonce="{}" src="foo"></script>"""
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_script_tag_sets_attrs_correctly(self):
+        tpl = """
+            {% load csp %}
+            {% script type="application/javascript" id="jeff" defer=True%}
+                var hello='world';
+            {% endscript %}"""
+
+        expected = (
+            '<script'
+            ' nonce="{}" id="jeff" type="application/javascript" defer>'
+            'var hello=\'world\';</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_async_attribute_with_falsey(self):
+        tpl = """
+            {% load csp %}
+            {% script src="foo.com/bar.js" async=False %}
+            {% endscript %}"""
+
+        expected = ('<script nonce="{}" src="foo.com/bar.js" async=false>'
+                    '</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_async_attribute_with_truthy(self):
+        tpl = """
+            {% load csp %}
+            {% script src="foo.com/bar.js" async=True %}
+                var hello='world';
+            {% endscript %}"""
+
+        expected = '<script nonce="{}" src="foo.com/bar.js" async></script>'
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_nested_script_tags_are_removed(self):
+        """Lets end users wrap their code in script tags for the sake of their
+           development environment"""
+        tpl = """
+            {% load csp %}
+            {% script type="application/javascript" id="jeff" defer=True%}
+                <script type="text/javascript">
+                var hello='world';
+                </script>
+            {% endscript %}"""
+
+        expected = (
+            '<script'
+            ' nonce="{}" id="jeff" type="application/javascript" defer>'
+            'var hello=\'world\';</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
+import pytest
 from django.test.utils import override_settings
 from django.utils.functional import lazy
 from django.utils import six
-import pytest
 
 from csp.utils import build_policy
 

--- a/csp/tests/utils.py
+++ b/csp/tests/utils.py
@@ -1,0 +1,39 @@
+from django.template import engines, Template, Context
+from django.test import RequestFactory
+
+from csp.middleware import CSPMiddleware
+
+
+JINJA_ENV = engines['jinja2']
+mw = CSPMiddleware()
+rf = RequestFactory()
+
+
+class ScriptTestBase(object):
+    def assert_template_eq(self, tpl1, tpl2):
+        aaa = tpl1.replace('\n', '').replace('  ', '')
+        bbb = tpl2.replace('\n', '').replace('  ', '')
+        assert aaa == bbb
+
+    def process_templates(self, tpl, expected):
+        request = rf.get('/')
+        mw.process_request(request)
+        ctx = self.make_context(request)
+        return (self.make_template(tpl).render(ctx).strip(),
+                expected.format(request.csp_nonce))
+
+
+class ScriptTagTestBase(ScriptTestBase):
+    def make_context(self, request):
+        return Context({'request': request})
+
+    def make_template(self, tpl):
+        return Template(tpl)
+
+
+class ScriptExtensionTestBase(ScriptTestBase):
+    def make_context(self, request):
+        return {'request': request}
+
+    def make_template(self, tpl):
+        return JINJA_ENV.from_string(tpl)

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -1,8 +1,12 @@
+import copy
+import re
+import warnings
+
+from collections import OrderedDict
+from itertools import chain
+
 from django.conf import settings
 from django.utils.encoding import force_text
-import copy
-from itertools import chain
-import warnings
 
 
 CHILD_SRC_DEPRECATION_WARNING = \
@@ -95,3 +99,68 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
 
     return '; '.join(['{} {}'.format(k, val).strip()
                       for k, val in policy_parts.items()])
+
+
+def _default_attr_mapper(attr_name, val):
+    if val:
+        return ' {}="{}"'.format(attr_name, val)
+    else:
+        return ''
+
+
+def _bool_attr_mapper(attr_name, val):
+    # Only return the bare word if the value is truthy
+    # ie - defer=False should actually return an empty string
+    if val:
+        return ' {}'.format(attr_name)
+    else:
+        return ''
+
+
+def _async_attr_mapper(attr_name, val):
+    """The `async` attribute works slightly different than the other bool
+    attributes. It can be set explicitly to `false` with no surrounding quotes
+    according to the spec."""
+    if val in [False, 'False']:
+        return ' {}=false'.format(attr_name)
+    elif val:
+        return ' {}'.format(attr_name)
+    else:
+        return ''
+
+
+# Allow per-attribute customization of returned string template
+SCRIPT_ATTRS = OrderedDict()
+SCRIPT_ATTRS['nonce'] = _default_attr_mapper
+SCRIPT_ATTRS['id'] = _default_attr_mapper
+SCRIPT_ATTRS['src'] = _default_attr_mapper
+SCRIPT_ATTRS['type'] = _default_attr_mapper
+SCRIPT_ATTRS['async'] = _async_attr_mapper
+SCRIPT_ATTRS['defer'] = _bool_attr_mapper
+SCRIPT_ATTRS['integrity'] = _default_attr_mapper
+SCRIPT_ATTRS['nomodule'] = _bool_attr_mapper
+
+# Generates an interpolatable string of valid attrs eg - '{nonce}{id}...'
+ATTR_FORMAT_STR = ''.join(['{{{}}}'.format(a) for a in SCRIPT_ATTRS])
+
+
+def _unwrap_script(text):
+    """Extract content defined between script tags"""
+    matches = re.search(r'<script[\s|\S]*>([\s|\S]+?)</script>', text)
+    if matches and len(matches.groups()):
+        return matches.group(1).strip()
+
+    return text
+
+
+def build_script_tag(content=None, **kwargs):
+    data = {}
+    # Iterate all possible script attrs instead of kwargs to make
+    # interpolation as easy as possible below
+    for attr_name, mapper in SCRIPT_ATTRS.items():
+        data[attr_name] = mapper(attr_name, kwargs.get(attr_name))
+
+    # Don't render block contents if the script has a 'src' attribute
+    c = _unwrap_script(content) if content and not kwargs.get('src') else ''
+    attrs = ATTR_FORMAT_STR.format(**data).rstrip()
+    return ('<script{}>{}</script>'.format(attrs, c).strip())

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,6 +81,8 @@ These settings affect the policy in the header. The defaults are in
 ``CSP_BLOCK_ALL_MIXED_CONTENT``
     Include ``block-all-mixed-content`` directive. A boolean. *False*
     See: block-all-mixed-content_
+``CSP_INCLUDE_NONCE_IN``
+    Include dynamically generated nonce in all listed directives, e.g. ``CSP_INCLUDE_NONCE_IN=['script-src']`` will add ``'nonce-<b64-value>'`` to the ``script-src`` directive. A tuple or list. *None*
 
 
 Changing the Policy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents:
    installation
    configuration
    decorators
+   nonce
    reports
    contributing
 

--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -1,0 +1,75 @@
+==============================
+Using the generated CSP nonce
+==============================
+When ``CSP_INCLUDE_NONCE_IN`` is configured, the nonce value is returned in the CSP header. To actually make the browser do anything with this value, you will need to include it in the attributes of the tags that you wish to mark as safe.
+
+``Middleware``
+==============
+Installing the middleware creates a lazily evaluated property ``csp_nonce`` and attaches it to all incoming requests.
+
+.. code-block:: python
+
+	MIDDLEWARE_CLASSES = (
+    	#...
+    	'csp.middleware.CSPMiddleware',
+    	#...
+    )
+
+This value can be accessed directly on the request object in any view or template and manually appended to any script element like so -
+
+.. code-block:: html
+
+	<script nonce="{{request.csp_nonce}}">
+		var hello="world";
+	</script>
+
+Assuming the ``CSP_INCLUDE_NONCE_IN`` list contains the ``script-src`` directive, this will result in the above script being allowed.
+
+
+``Context Processor``
+=====================
+This library contains an optional context processor, adding ``csp.context_processors.nonce`` to your configured context processors exposes a variable called ``nonce`` into the global template context. This is simple shorthand for ``request.csp_nonce``, but can be useful if you have many occurences of script tags.
+
+.. code-block:: jinja
+
+    <script nonce="{{nonce}}">
+    	var hello="world";
+    </script>
+
+
+``Django Template Tag/Jinja Extension``
+=======================================
+Since it can be easy to forget to include the ``nonce`` property in a script tag, there is also a ``script`` template tag available for both Django templates and Jinja environments.
+
+This tag will output a properly nonced script every time. For the sake of syntax highlighting, you can wrap the content inside of the ``script`` tag in ``<script>`` html tags, which will be subsequently removed in the rendered output. Any valid script tag attributes can be specified and will be forwarded into the rendered html.
+
+Django:
+
+.. code-block:: jinja
+
+	{% load csp %}
+	{% script type="application/javascript" async=False %}
+		<script>
+			var hello='world';
+		</script>
+	{% endscript %}
+
+
+Jinja:
+
+(assumes ``csp.extensions.NoncedScript`` is added to the jinja extensions setting)
+
+.. code-block:: jinja
+
+	{% script type="application/javascript" async=False %}
+		<script>
+			var hello='world';
+		</script>
+	{% endscript %}
+
+Will output -
+
+.. code-block:: html
+
+	<script nonce='123456' type="application/javascript" async=false></script>
+

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ def read(*parts):
 
 install_requires = [
     'Django>=1.8',
+    'jinja2>=2.9.6'
 ]
 
 


### PR DESCRIPTION
First pass at a template tag based on the pr #75. This creates a `{% script %}` and {% endscript %}` token that will wrap whatever is inside with a nonce-signed script tag and prevent anything besides text nodes being expanded inside of the block. 

#### Caveats

* This definitely needs some docs ~~and tests~~
* ~~There is also no `type` parameter in the script tag that is generated, I'm not clear on how big of a problem that is, but it should be easy enough to take a type argument~~

* ~~No Jinja support yet. Frankly, I don't know a ton about it but this could provide a good jumping off point?~~