### PR TITLE
add deprecation warning for child-src

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,11 @@
 CHANGES
 =======
 
+v3.0.1
+======
+
+- Add deprecation warning for child-src
+
 v3.0
 ====
 

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,6 +1,7 @@
 from django.test.utils import override_settings
 from django.utils.functional import lazy
 from django.utils import six
+import pytest
 
 from csp.utils import build_policy
 
@@ -167,8 +168,9 @@ def test_base_uri():
 
 @override_settings(CSP_CHILD_SRC=['example.com'])
 def test_child_src():
-    policy = build_policy()
-    policy_eq("default-src 'self'; child-src example.com", policy)
+    with pytest.warns(DeprecationWarning):
+        policy = build_policy()
+        policy_eq("default-src 'self'; child-src example.com", policy)
 
 
 @override_settings(CSP_FRAME_ANCESTORS=['example.com'])

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -6,7 +6,7 @@ import warnings
 
 
 CHILD_SRC_DEPRECATION_WARNING = \
-    'child-src is deprecated in CSP v3.  Use frame-src and worker-src.'
+    'child-src is deprecated in CSP v3. Use frame-src and worker-src.'
 
 
 def from_settings():

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -2,6 +2,11 @@ from django.conf import settings
 from django.utils.encoding import force_text
 import copy
 from itertools import chain
+import warnings
+
+
+CHILD_SRC_DEPRECATION_WARNING = \
+    'child-src is deprecated in CSP v3.  Use frame-src and worker-src.'
 
 
 def from_settings():
@@ -71,6 +76,9 @@ def build_policy(config=None, update=None, replace=None):
             pass
         else:  # directives with many values like src lists
             policy_parts.append('%s %s' % (key, ' '.join(value)))
+
+        if key == 'child-src':
+            warnings.warn(CHILD_SRC_DEPRECATION_WARNING, DeprecationWarning)
 
     if report_uri:
         report_uri = map(force_text, report_uri)


### PR DESCRIPTION
refs: #80

Using the stdlib `warnings.catch_warnings` was timing out and `pytest.deprecated_call` gave me `AssertionError: <type 'exceptions.DeprecationWarning'> did not produce DeprecationWarning`.