### PR TITLE
Allow removing directives using @csp_replace

### DIFF
--- a/csp/tests/test_decorators.py
+++ b/csp/tests/test_decorators.py
@@ -65,6 +65,14 @@ def test_csp_replace():
     policy_list = sorted(response['Content-Security-Policy'].split("; "))
     assert policy_list == ["default-src 'self'", "img-src foo.com"]
 
+    @csp_replace(IMG_SRC=None)
+    def view_removing_directive(request):
+        return HttpResponse()
+    response = view_removing_directive(REQUEST)
+    mw.process_response(REQUEST, response)
+    policy_list = sorted(response["Content-Security-Policy"].split("; "))
+    assert policy_list == ["default-src 'self'"]
+
 
 def test_csp():
     def view_without_decorator(request):

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -49,7 +49,10 @@ def build_policy(config=None, update=None, replace=None):
     csp = {}
 
     for k in set(chain(config, replace)):
-        v = replace.get(k) or config[k]
+        if k in replace:
+            v = replace[k]
+        else:
+            v = config[k]
         if v is not None:
             v = copy.copy(v)
             if not isinstance(v, (list, tuple)):


### PR DESCRIPTION
In mozilla/normandy#604 we need to allow framing by any origin for only a particular view in our app. The only way we can do this (as far I've found) is to remove the `frame-ancestors` directive completely. We also want to have this directive set by default.

The current version of `@csp_replace` can't do this, because any value that would remove the directive is falsey, and `@csp_replace` doesn't allow falsey values to replace defaults. I think this is an oversight.

The code in this PR fixes this by accepting any values from `@csp_replace`, even falsey ones.