### PR TITLE
Add support for Django 1.11 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ python:
   - '2.7'
   - '3.4'
   - '3.5'
+  - '3.6'
   - pypy
 
 env:
+  - DJANGO_VERSION=1.11.x
   - DJANGO_VERSION=1.10.x
   - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
@@ -20,6 +22,16 @@ matrix:
     - python: '3.5'
       env: DJANGO_VERSION=1.7.x
     - python: '3.5'
+      env: DJANGO_VERSION=1.6.x
+    - python: '3.6'
+      env: DJANGO_VERSION=1.10.x
+    - python: '3.6'
+      env: DJANGO_VERSION=1.9.x
+    - python: '3.6'
+      env: DJANGO_VERSION=1.8.x
+    - python: '3.6'
+      env: DJANGO_VERSION=1.7.x
+    - python: '3.6'
       env: DJANGO_VERSION=1.6.x
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.6,<1.11',
+    'Django>=1.6,<2.0',
 ]
 
 
@@ -70,6 +70,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
         'Framework :: Django',

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ deps19 =
     https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
 deps110 =
     https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
+deps111 =
+    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
 
 
 [testenv:2.7-1.6.x]
@@ -45,6 +47,11 @@ basepython = python2.7
 deps =
     {[testenv]deps110}
 
+[testenv:2.7-1.11.x]
+basepython = python2.7
+deps =
+    {[testenv]deps111}
+
 [testenv:3.4-1.6.x]
 basepython = python3.4
 deps =
@@ -70,6 +77,11 @@ basepython = python3.4
 deps =
     {[testenv]deps110}
 
+[testenv:3.4-1.11.x]
+basepython = python3.4
+deps =
+    {[testenv]deps111}
+
 [testenv:3.5-1.8.x]
 basepython = python3.5
 deps =
@@ -84,6 +96,16 @@ deps =
 basepython = python3.5
 deps =
     {[testenv]deps110}
+
+[testenv:3.5-1.11.x]
+basepython = python3.5
+deps =
+    {[testenv]deps111}
+
+[testenv:3.6-1.11.x]
+basepython = python3.6
+deps =
+    {[testenv]deps111}
 
 [testenv:pypy-1.6.x]
 basepython = pypy
@@ -109,3 +131,8 @@ deps =
 basepython = pypy
 deps =
     {[testenv]deps110}
+
+[testenv:pypy-1.11.x]
+basepython = pypy
+deps =
+    {[testenv]deps111}


### PR DESCRIPTION
Django 1.11 has been released, so it's time to support it!