### PR TITLE
Remove upper bound on Django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.6,<2.0',
+    'Django>=1.6',
 ]
 
 


### PR DESCRIPTION
Django's backwards compatibility and deprecation policies mean that any future compatibility issues will be known well in advance of any breakage. There is no advantage to pinning the upper bound on the supported Django version. It means a django-csp release is required to support each version of Django (and we're currently waiting on a django-csp release to upgrade to Django 1.11).