### PR TITLE
Use a custom class when raising csp-related deprecation warnings

### DIFF
--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -3,7 +3,7 @@ from django.utils.functional import lazy
 from django.utils import six
 import pytest
 
-from csp.utils import build_policy
+from csp.utils import build_policy, CspDeprecationWarning
 
 
 def policy_eq(a, b, msg='%r != %r'):
@@ -168,7 +168,7 @@ def test_base_uri():
 
 @override_settings(CSP_CHILD_SRC=['example.com'])
 def test_child_src():
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(CspDeprecationWarning):
         policy = build_policy()
         policy_eq("default-src 'self'; child-src example.com", policy)
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -9,6 +9,10 @@ CHILD_SRC_DEPRECATION_WARNING = \
     'child-src is deprecated in CSP v3. Use frame-src and worker-src.'
 
 
+class CspDeprecationWarning(DeprecationWarning):
+    pass
+
+
 def from_settings():
     return {
         'default-src': getattr(settings, 'CSP_DEFAULT_SRC', ["'self'"]),
@@ -78,7 +82,7 @@ def build_policy(config=None, update=None, replace=None):
             policy_parts.append('%s %s' % (key, ' '.join(value)))
 
         if key == 'child-src':
-            warnings.warn(CHILD_SRC_DEPRECATION_WARNING, DeprecationWarning)
+            warnings.warn(CHILD_SRC_DEPRECATION_WARNING, CspDeprecationWarning)
 
     if report_uri:
         report_uri = map(force_text, report_uri)


### PR DESCRIPTION
This allows consumers of the app to filter those warnings out by filtering on the class.