### PR TITLE
Drop old django 1.6 and 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,15 @@ env:
   - DJANGO_VERSION=1.10.x
   - DJANGO_VERSION=1.9.x
   - DJANGO_VERSION=1.8.x
-  - DJANGO_VERSION=1.7.x
-  - DJANGO_VERSION=1.6.x
 
 matrix:
   exclude:
-    - python: '3.5'
-      env: DJANGO_VERSION=1.7.x
-    - python: '3.5'
-      env: DJANGO_VERSION=1.6.x
     - python: '3.6'
       env: DJANGO_VERSION=1.10.x
     - python: '3.6'
       env: DJANGO_VERSION=1.9.x
     - python: '3.6'
       env: DJANGO_VERSION=1.8.x
-    - python: '3.6'
-      env: DJANGO_VERSION=1.7.x
-    - python: '3.6'
-      env: DJANGO_VERSION=1.6.x
 
 install:
   - pip install tox

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,19 @@
 CHANGES
 =======
 
+3.4
+===
+
+- Remove support for Django 1.6 and 1.7 as they're out of life
+- Allow removing directives using @csp_replace
+- Add CSP nonce support
+
+3.3
+===
+
+- Add support for Django 1.11
+- Add support for Python 3.6
+
 3.2
 ===
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.6',
+    'Django>=1.8',
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,6 @@ commands =
     pip install --use-wheel -e .[tests]
     py.test {toxinidir}/csp
 
-deps16 =
-    https://github.com/django/django/archive/stable/1.6.x.tar.gz#egg=django
-deps17 =
-    https://github.com/django/django/archive/stable/1.7.x.tar.gz#egg=django
 deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
 deps19 =
@@ -21,16 +17,6 @@ deps110 =
 deps111 =
     https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
 
-
-[testenv:2.7-1.6.x]
-basepython = python2.7
-deps =
-    {[testenv]deps16}
-
-[testenv:2.7-1.7.x]
-basepython = python2.7
-deps =
-    {[testenv]deps17}
 
 [testenv:2.7-1.8.x]
 basepython = python2.7
@@ -51,16 +37,6 @@ deps =
 basepython = python2.7
 deps =
     {[testenv]deps111}
-
-[testenv:3.4-1.6.x]
-basepython = python3.4
-deps =
-    {[testenv]deps16}
-
-[testenv:3.4-1.7.x]
-basepython = python3.4
-deps =
-    {[testenv]deps17}
 
 [testenv:3.4-1.8.x]
 basepython = python3.4
@@ -106,16 +82,6 @@ deps =
 basepython = python3.6
 deps =
     {[testenv]deps111}
-
-[testenv:pypy-1.6.x]
-basepython = pypy
-deps =
-    {[testenv]deps16}
-
-[testenv:pypy-1.7.x]
-basepython = pypy
-deps =
-    {[testenv]deps17}
 
 [testenv:pypy-1.8.x]
 basepython = pypy


### PR DESCRIPTION
This also adds changelog entries for 3.3 and upcoming 3.4 releases