### PR TITLE
Add CSP_REPORT_PERCENTAGE option

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,3 +1,4 @@
+import random
 from functools import partial
 
 from django.conf import settings
@@ -65,6 +66,10 @@ class CSPMiddleware(MiddlewareMixin):
         replace = getattr(response, '_csp_replace', None)
         nonce = getattr(request, '_csp_nonce', None)
 
+        report_percentage = getattr(settings, 'CSP_REPORT_PERCENTAGE', 1)
+        include_report_uri = random.random() < report_percentage
+
         response[header] = build_policy(config=config, update=update,
-                                        replace=replace, nonce=nonce)
+                                        replace=replace, nonce=nonce,
+                                        include_report_uri=include_report_uri)
         return response

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -126,3 +126,16 @@ def test_no_nonce_when_disabled_by_settings():
     response = HttpResponse()
     mw.process_response(request, response)
     assert nonce not in response[HEADER]
+
+
+@override_settings(CSP_REPORT_PERCENTAGE=0.1, CSP_REPORT_URI='x')
+def test_report_percentage():
+    times_seen = 0
+    for _ in range(1000):
+        request = rf.get('/')
+        response = HttpResponse()
+        mw.process_response(request, response)
+        if 'report-uri' in response[HEADER]:
+            times_seen += 1
+    # Roughly 10%
+    assert 80 <= times_seen <= 120

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -102,6 +102,12 @@ def test_report_uri_lazy():
     policy_eq("default-src 'self'; report-uri /foo", policy)
 
 
+@override_settings(CSP_REPORT_URI='/foo')
+def test_report_uri_skip():
+    policy = build_policy(include_report_uri=False)
+    policy_eq("default-src 'self'", policy)
+
+
 @override_settings(CSP_IMG_SRC=['example.com'])
 def test_update_img():
     policy = build_policy(update={'img-src': 'example2.com'})

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -37,7 +37,8 @@ def from_settings():
     }
 
 
-def build_policy(config=None, update=None, replace=None, nonce=None):
+def build_policy(config=None, update=None, replace=None, nonce=None,
+                 include_report_uri=True):
     """Builds the policy as a string from the settings."""
 
     if config is None:
@@ -83,7 +84,7 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
         if key == 'child-src':
             warnings.warn(CHILD_SRC_DEPRECATION_WARNING, DeprecationWarning)
 
-    if report_uri:
+    if report_uri and include_report_uri:
         report_uri = map(force_text, report_uri)
         policy_parts['report-uri'] = ' '.join(report_uri)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,6 +64,11 @@ These settings affect the policy in the header. The defaults are in
     Set the ``report-uri`` directive. A **string** with a full or
     relative URI.
     Note: This doesn't use default-src as a fall-back.
+``CSP_REPORT_PERCENTAGE``
+    Percentage of requests that should see the ``report-uri`` directive.
+    Use this to throttle the number of CSP violation reports made to your
+    ``CSP_REPORT_URI``. A **float** between 0 and 1 (0 = no reports at all).
+    Ignored if ``CSP_REPORT_URI`` isn't set.
 ``CSP_MANIFEST_SRC``
     Set the ``manifest-src`` directive. A tuple or list. *None*
 ``CSP_WORKER_SRC``


### PR DESCRIPTION
Throttle the number of requests made to your report endpoint. Simple implementation that only sends `report-uri` for a certain percentage of requests.