### PR TITLE
Remove --use-wheel from pip calls

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 commands =
     pip install --upgrade pip setuptools wheel
-    pip install --use-wheel -e .
-    pip install --use-wheel -e .[tests]
+    pip install -e .
+    pip install -e .[tests]
     py.test {toxinidir}/csp
 basepython =
     2.7: python2.7


### PR DESCRIPTION
``--use-wheel`` was [deprecated in pip 7](https://pip.pypa.io/en/stable/news/#id25), and dropped in [pip 10](https://pip.pypa.io/en/stable/news/#b1-2018-03-31). Thanks to https://stackoverflow.com/a/50171690/10612 for the links.