### PR TITLE
Add new headers used in CSP level 3 - https://w3c.github.io/webappsec-csp/

### DIFF
--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -40,13 +40,13 @@ def test_script_src():
 
 
 @override_settings(CSP_SCRIPT_SRC_ATTR=['example.com'])
-def test_script_src():
+def test_script_src_attr():
     policy = build_policy()
     policy_eq("default-src 'self'; script-src-attr example.com", policy)
 
 
 @override_settings(CSP_SCRIPT_SRC_ELEM=['example.com'])
-def test_script_src():
+def test_script_src_elem():
     policy = build_policy()
     policy_eq("default-src 'self'; script-src-elem example.com", policy)
 
@@ -64,13 +64,13 @@ def test_style_src():
 
 
 @override_settings(CSP_STYLE_SRC_ATTR=['example.com'])
-def test_style_src():
+def test_style_src_attr():
     policy = build_policy()
     policy_eq("default-src 'self'; style-src-attr example.com", policy)
 
 
 @override_settings(CSP_STYLE_SRC_ELEM=['example.com'])
-def test_style_src():
+def test_style_src_elem():
     policy = build_policy()
     policy_eq("default-src 'self'; style-src-elem example.com", policy)
 

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -39,6 +39,18 @@ def test_script_src():
     policy_eq("default-src 'self'; script-src example.com", policy)
 
 
+@override_settings(CSP_SCRIPT_SRC_ATTR=['example.com'])
+def test_script_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; script-src-attr example.com", policy)
+
+
+@override_settings(CSP_SCRIPT_SRC_ELEM=['example.com'])
+def test_script_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; script-src-elem example.com", policy)
+
+
 @override_settings(CSP_OBJECT_SRC=['example.com'])
 def test_object_src():
     policy = build_policy()
@@ -49,6 +61,18 @@ def test_object_src():
 def test_style_src():
     policy = build_policy()
     policy_eq("default-src 'self'; style-src example.com", policy)
+
+
+@override_settings(CSP_STYLE_SRC_ATTR=['example.com'])
+def test_style_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; style-src-attr example.com", policy)
+
+
+@override_settings(CSP_STYLE_SRC_ELEM=['example.com'])
+def test_style_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; style-src-elem example.com", policy)
 
 
 @override_settings(CSP_IMG_SRC=['example.com'])

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -17,8 +17,12 @@ def from_settings():
     return {
         'default-src': getattr(settings, 'CSP_DEFAULT_SRC', ["'self'"]),
         'script-src': getattr(settings, 'CSP_SCRIPT_SRC', None),
+        'script-src-attr': getattr(settings, 'CSP_SCRIPT_SRC_ATTR', None),
+        'script-src-elem': getattr(settings, 'CSP_SCRIPT_SRC_ELEM', None),
         'object-src': getattr(settings, 'CSP_OBJECT_SRC', None),
         'style-src': getattr(settings, 'CSP_STYLE_SRC', None),
+        'style-src-attr': getattr(settings, 'CSP_STYLE_SRC_ATTR', None),
+        'style-src-elem': getattr(settings, 'CSP_STYLE_SRC_ELEM', None),
         'img-src': getattr(settings, 'CSP_IMG_SRC', None),
         'media-src': getattr(settings, 'CSP_MEDIA_SRC', None),
         'frame-src': getattr(settings, 'CSP_FRAME_SRC', None),

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,6 +32,10 @@ These settings affect the policy in the header. The defaults are in
     values, e.g. ``("'self'", 'cdn.example.net')``. *'self'*
 ``CSP_SCRIPT_SRC``
     Set the ``script-src`` directive. A tuple or list. *None*
+``CSP_SCRIPT_SRC_ATTR``
+    Set the ``script-src-attr`` directive. A tuple or list. *None*
+``CSP_SCRIPT_SRC_ELEM``
+    Set the ``script-src-elem`` directive. A tuple or list. *None*
 ``CSP_IMG_SRC``
     Set the ``img-src`` directive. A tuple or list. *None*
 ``CSP_OBJECT_SRC``
@@ -46,6 +50,10 @@ These settings affect the policy in the header. The defaults are in
     Set the ``connect-src`` directive. A tuple or list. *None*
 ``CSP_STYLE_SRC``
     Set the ``style-src`` directive. A tuple or list. *None*
+``CSP_STYLE_SRC_ATTR``
+    Set the ``style-src-attr`` directive. A tuple or list. *None*
+``CSP_STYLE_SRC_ELEM``
+    Set the ``style-src-elem`` directive. A tuple or list. *None*
 ``CSP_BASE_URI``
     Set the ``base-uri`` directive. A tuple or list. *None*
     Note: This doesn't use default-src as a fall-back.


### PR DESCRIPTION
Should address this issue https://github.com/mozilla/django-csp/issues/108
The PR might be a bit off, I just tried to copy the format which was used for all of the other headers. New directives are script-src-attr, script-src-elem, style-src-attr, and style-src-elem