### PR TITLE
Add prefetch-src, navigate-to level 3directives

### DIFF
--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -57,6 +57,12 @@ def test_object_src():
     policy_eq("default-src 'self'; object-src example.com", policy)
 
 
+@override_settings(CSP_PREFETCH_SRC=['example.com'])
+def test_object_src():
+    policy = build_policy()
+    policy_eq("default-src 'self'; prefetch-src example.com", policy)
+
+
 @override_settings(CSP_STYLE_SRC=['example.com'])
 def test_style_src():
     policy = build_policy()
@@ -204,6 +210,12 @@ def test_child_src():
 def test_frame_ancestors():
     policy = build_policy()
     policy_eq("default-src 'self'; frame-ancestors example.com", policy)
+
+
+@override_settings(CSP_NAVIGATE_TO=['example.com'])
+def test_navigate_to():
+    policy = build_policy()
+    policy_eq("default-src 'self'; navigate-to example.com", policy)
 
 
 @override_settings(CSP_MANIFEST_SRC=['example.com'])

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -58,7 +58,7 @@ def test_object_src():
 
 
 @override_settings(CSP_PREFETCH_SRC=['example.com'])
-def test_object_src():
+def test_prefetch_src():
     policy = build_policy()
     policy_eq("default-src 'self'; prefetch-src example.com", policy)
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -15,6 +15,9 @@ CHILD_SRC_DEPRECATION_WARNING = \
 
 def from_settings():
     return {
+        # Fetch Directives
+        'child-src': getattr(settings, 'CSP_CHILD_SRC', None),
+        'connect-src': getattr(settings, 'CSP_CONNECT_SRC', None),
         'default-src': getattr(settings, 'CSP_DEFAULT_SRC', ["'self'"]),
         'script-src': getattr(settings, 'CSP_SCRIPT_SRC', None),
         'script-src-attr': getattr(settings, 'CSP_SCRIPT_SRC_ATTR', None),
@@ -23,21 +26,25 @@ def from_settings():
         'style-src': getattr(settings, 'CSP_STYLE_SRC', None),
         'style-src-attr': getattr(settings, 'CSP_STYLE_SRC_ATTR', None),
         'style-src-elem': getattr(settings, 'CSP_STYLE_SRC_ELEM', None),
-        'img-src': getattr(settings, 'CSP_IMG_SRC', None),
-        'media-src': getattr(settings, 'CSP_MEDIA_SRC', None),
-        'frame-src': getattr(settings, 'CSP_FRAME_SRC', None),
         'font-src': getattr(settings, 'CSP_FONT_SRC', None),
-        'connect-src': getattr(settings, 'CSP_CONNECT_SRC', None),
-        'sandbox': getattr(settings, 'CSP_SANDBOX', None),
-        'report-uri': getattr(settings, 'CSP_REPORT_URI', None),
+        'frame-src': getattr(settings, 'CSP_FRAME_SRC', None),
+        'img-src': getattr(settings, 'CSP_IMG_SRC', None),
+        'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
+        'media-src': getattr(settings, 'CSP_MEDIA_SRC', None),
+        'prefetch-src': getattr(settings, 'CSP_PREFETCH_SRC', None),
+        'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
+        # Document Directives
         'base-uri': getattr(settings, 'CSP_BASE_URI', None),
-        'child-src': getattr(settings, 'CSP_CHILD_SRC', None),
+        'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
+        'sandbox': getattr(settings, 'CSP_SANDBOX', None),
+        # Navigation Directives
         'form-action': getattr(settings, 'CSP_FORM_ACTION', None),
         'frame-ancestors': getattr(settings, 'CSP_FRAME_ANCESTORS', None),
-        'manifest-src': getattr(settings, 'CSP_MANIFEST_SRC', None),
-        'worker-src': getattr(settings, 'CSP_WORKER_SRC', None),
-        'plugin-types': getattr(settings, 'CSP_PLUGIN_TYPES', None),
+        'navigate-to': getattr(settings, 'CSP_NAVIGATE_TO', None),
+        # Reporting Directives
+        'report-uri': getattr(settings, 'CSP_REPORT_URI', None),
         'require-sri-for': getattr(settings, 'CSP_REQUIRE_SRI_FOR', None),
+        # Other Directives
         'upgrade-insecure-requests': getattr(
             settings, 'CSP_UPGRADE_INSECURE_REQUESTS', False),
         'block-all-mixed-content': getattr(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -40,6 +40,8 @@ These settings affect the policy in the header. The defaults are in
     Set the ``img-src`` directive. A tuple or list. *None*
 ``CSP_OBJECT_SRC``
     Set the ``object-src`` directive. A tuple or list. *None*
+``CSP_PREFETCH_SRC``
+    Set the ``prefetch-src`` directive. A tuple or list. *None*
 ``CSP_MEDIA_SRC``
     Set the ``media-src`` directive. A tuple or list. *None*
 ``CSP_FRAME_SRC``
@@ -60,7 +62,10 @@ These settings affect the policy in the header. The defaults are in
 ``CSP_CHILD_SRC``
     Set the ``child-src`` directive. A tuple or list. *None* Note: Deprecated in CSP v3. Use frame-src and worker-src instead.
 ``CSP_FRAME_ANCESTORS``
-    Set the ``FRAME_ANCESTORS`` directive. A tuple or list. *None*
+    Set the ``frame-ancestors`` directive. A tuple or list. *None*
+    Note: This doesn't use default-src as a fall-back.
+``CSP_NAVIGATE_TO``
+    Set the ``navigate-to`` directive. A tuple or list. *None*
     Note: This doesn't use default-src as a fall-back.
 ``CSP_FORM_ACTION``
     Set the ``FORM_ACTION`` directive. A tuple or list. *None*
@@ -123,6 +128,7 @@ These settings control the behavior of django-csp. Defaults are in
    on the same origin.
 
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/
+.. _Content-Security-Policy-L3: https://w3c.github.io/webappsec-csp/
 .. _spec: Content-Security-Policy_
 .. _require-sri-for-known-tokens: https://w3c.github.io/webappsec-subresource-integrity/#opt-in-require-sri-for
 .. _upgrade-insecure-requests: https://w3c.github.io/webappsec-upgrade-insecure-requests/#delivery


### PR DESCRIPTION
Also typo fix FRAME_ANCESTOR doc, and order utils.py directives in the same way that the CSP level 3 docs orders them. I was going to reoder the docs and the tests in the same way, but then I got lazy. Sorry.