### PR TITLE
tox: add missing versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 addopts = -vs --tb=short --pep8 --flakes
 
 DJANGO_SETTINGS_MODULE = csp.tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     {3.5,3.6,pypy3}-master,
+    {2.7,3.4,3.5,3.6,pypy,pypy3}-2.1.x,
     {3.4,3.5,3.6,pypy3}-2.0.x,
     {2.7,3.4,3.5,3.6,pypy,pypy3}-1.11.x,
     {2.7,3.4,3.5,3.6,pypy}-1.10.x,
@@ -16,7 +17,7 @@ commands =
     pip install pytest-cov
     pip install -e .
     pip install -e .[tests]
-    py.test --cov={toxinidir}/csp  {toxinidir}/csp 
+    py.test --cov={toxinidir}/csp  {toxinidir}/csp
 basepython =
     2.7: python2.7
     3.4: python3.4
@@ -29,5 +30,7 @@ deps=
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
+    1.11: Django>=1.11,<1.12
     2.0: Django>=2.0,<2.1
+    2.1: Django>=2.1,<2.2
     master: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Fix tox `ERROR: unknown environment '2.7-2.1.x'` errors for Django 2.1 and a pytest deprecation warning.