### PR TITLE
Fix pypi version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-.. image:: https://badge.fury.io/py/django_csp.svg
+.. image:: https://badge.fury.io/py/django-csp.svg
    :target: https://pypi.python.org/pypi/django_csp
 
 .. image:: https://travis-ci.org/mozilla/django-csp.svg?branch=master


### PR DESCRIPTION
pypi version badge seems busted, this fixes it.
before:
![Screenshot 2020-01-08 14 25 35](https://user-images.githubusercontent.com/1268088/72021393-c5618180-3222-11ea-9f92-9f06a9ea8b25.png)

after:
![Screenshot 2020-01-08 14 26 02](https://user-images.githubusercontent.com/1268088/72021439-db6f4200-3222-11ea-8e00-6e30f37576ed.png)

(visible at: https://github.com/asherf/django-csp/blob/fix-badge/README.rst)