### PR TITLE
Fix #125: Document correct context variable name

### DIFF
--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -28,11 +28,11 @@ Assuming the ``CSP_INCLUDE_NONCE_IN`` list contains the ``script-src`` directive
 
 ``Context Processor``
 =====================
-This library contains an optional context processor, adding ``csp.context_processors.nonce`` to your configured context processors exposes a variable called ``nonce`` into the global template context. This is simple shorthand for ``request.csp_nonce``, but can be useful if you have many occurrences of script tags.
+This library contains an optional context processor, adding ``csp.context_processors.nonce`` to your configured context processors exposes a variable called ``CSP_NONCE`` into the global template context. This is simple shorthand for ``request.csp_nonce``, but can be useful if you have many occurrences of script tags.
 
 .. code-block:: jinja
 
-    <script nonce="{{nonce}}">
+    <script nonce="{{CSP_NONCE}}">
     	var hello="world";
     </script>
 


### PR DESCRIPTION
As noted in issue #125 the context processors actually adds a variable with the name `CSP_NONCE` to the context.