### PR TITLE
Add expected script to output

### DIFF
--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -76,5 +76,5 @@ Will output -
 
 .. code-block:: html
 
-	<script nonce='123456' type="application/javascript" async=false></script>
+	<script nonce='123456' type="application/javascript" async=false>var hello='world';</script>
 


### PR DESCRIPTION
I did not test this, but I assume the Django templatetag and Jinja2 extension include the actual script code in the output.