### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,5 +24,6 @@ to ``MIDDLEWARE``, like so::
         'csp.middleware.CSPMiddleware',
         # ...
     )
+Note: Middleware order does not matter unless you have other middleware modifying the CSP header.
 
 That should do it! Go on to :ref:`configuring CSP <configuration-chapter>`.


### PR DESCRIPTION
Reference to closed issue #162

In Django, some Middleware are required to be added before or after others. I've came across this ordering requirement when implementing `django.middleware.cache.*` and `django.middleware.security.*`. 

This pull request informs any new users that they are not required to maintain any sort of ordering when implementing `csp.middleware.CSPMiddleware`