### PR TITLE
Drop old Django and Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,86 +7,21 @@ workflows:
           matrix:
             parameters:
               python_image:
-                - "python:2.7-slim"
-                - "python:3.4-slim"
                 - "python:3.5-slim"
                 - "python:3.6-slim"
                 - "python:3.7-slim"
                 - "python:3.8-slim"
-                - "pypy:2-slim-buster"
+                - "python:3.9-slim"
                 - "pypy:3-slim-buster"
               django_version:
                 - "master"
-                - "3.0.x" # 3.x supports python 3.6 to 3.9
-                - "2.2.x" # 2.x supports python 3.4 to 3.7
-                - "2.1.x"
-                - "2.0.x"
-                - "1.11.x" # 1.11.x supports python 2.7
-                - "1.10.x"
-                - "1.9.x"
-                - "1.8.x"
+                - "3.0.x" # 3.0 supports python 3.6 to 3.9
+                - "2.2.x" # 2.2 supports python 3.5 to 3.9
             exclude:
-              - python_image: "python:3.8-slim"
-                django_version: "2.2.x"
-              - python_image: "python:3.8-slim"
-                django_version: "2.1.x"
-              - python_image: "python:3.8-slim"
-                django_version: "2.0.x"
-              - python_image: "python:3.8-slim"
-                django_version: "1.11.x"
-              - python_image: "python:3.8-slim"
-                django_version: "1.10.x"
-              - python_image: "python:3.8-slim"
-                django_version: "1.9.x"
-              - python_image: "python:3.8-slim"
-                django_version: "1.8.x"
-
-              - python_image: "python:3.7-slim"
-                django_version: "1.10.x"
-              - python_image: "python:3.7-slim"
-                django_version: "1.9.x"
-              - python_image: "python:3.7-slim"
-                django_version: "1.8.x"
-
-              - python_image: "python:3.6-slim"
-                django_version: "1.10.x"
-              - python_image: "python:3.6-slim"
-                django_version: "1.9.x"
-              - python_image: "python:3.6-slim"
-                django_version: "1.8.x"
-
               - python_image: "python:3.5-slim"
                 django_version: "master"
               - python_image: "python:3.5-slim"
                 django_version: "3.0.x"
-
-              - python_image: "python:3.4-slim"
-                django_version: "master"
-              - python_image: "python:3.4-slim"
-                django_version: "3.0.x"
-
-              - python_image: "python:2.7-slim"
-                django_version: "master"
-              - python_image: "python:2.7-slim"
-                django_version: "3.0.x"
-              - python_image: "python:2.7-slim"
-                django_version: "2.2.x"
-              - python_image: "python:2.7-slim"
-                django_version: "2.1.x"
-              - python_image: "python:2.7-slim"
-                django_version: "2.0.x"
-
-              - python_image: "pypy:2-slim-buster"
-                django_version: "master"
-              - python_image: "pypy:2-slim-buster"
-                django_version: "3.0.x"
-              - python_image: "pypy:2-slim-buster"
-                django_version: "2.2.x"
-              - python_image: "pypy:2-slim-buster"
-                django_version: "2.1.x"
-              - python_image: "pypy:2-slim-buster"
-                django_version: "2.0.x"
-
 jobs:
   test:
     parameters:
@@ -111,7 +46,6 @@ jobs:
           condition:
             not:
               or:
-                - equal: [ "pypy:2-slim-buster", << parameters.python_image >> ]
                 - equal: [ "pypy:3-slim-buster", << parameters.python_image >> ]
           steps:
             - run:
@@ -123,7 +57,6 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ "pypy:2-slim-buster", << parameters.python_image >> ]
               - equal: [ "pypy:3-slim-buster", << parameters.python_image >> ]
           steps:
             - run:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.db
 *.sw[po]
 .cache
+.coverage
 .tox
 dist
 build

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [tool:pytest]
 addopts = -vs --tb=short --pep8 --flakes
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*parts):
 
 
 install_requires = [
-    'Django>=1.8',
+    'Django>=2.2',
 ]
 
 jinja2_requires = [
@@ -32,6 +32,7 @@ jinja2_requires = [
 
 test_requires = [
     'pytest<4.0',
+    'pytest-cov',
     'pytest-django',
     'pytest-flakes==1.0.1',
     'pytest-pep8==1.0.6',
@@ -72,14 +73,11 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Programming Language :: Python :: Implementation :: CPython',
         'Framework :: Django',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,8 @@
 [tox]
 envlist =
-    {3.6,3.7,3.8,pypy3}-master,
-    {3.6,3.7,3.8,pypy3}-3.0.x,
-    {3.5,3.6,3,7,pypy3}-2.2.x,
-    {2.7,3.4,3.5,3.6,pypy,pypy3}-2.1.x,
-    {3.4,3.5,3.6,pypy3}-2.0.x,
-    {2.7,3.4,3.5,3.6,pypy,pypy3}-1.11.x,
-    {2.7,3.4,3.5,3.6,pypy}-1.10.x,
-    {2.7,3.4,3.5,3.6,pypy}-1.9.x,
-    {2.7,3.4,3.5,3.6,pypy}-1.8.x
+    {3.6,3.7,3.8,3.9,pypy3}-main
+    {3.6,3.7,3.8,3.9,pypy3}-3.0.x
+    {3.6,3,7,3.8,3.9,pypy3}-2.2.x
 
 [testenv]
 setenv =
@@ -16,27 +10,17 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 commands =
     pip install --upgrade pip setuptools wheel
-    pip install pytest-cov
-    pip install -e .
     pip install -e .[tests]
-    py.test --cov={toxinidir}/csp  {toxinidir}/csp
+    pytest --cov={toxinidir}/csp  {toxinidir}/csp
 basepython =
-    2.7: python2.7
-    3.4: python3.4
     3.5: python3.5
     3.6: python3.6
     3.7: python3.7
     3.8: python3.8
-    pypy: pypy
+    3.9: python3.8
     pypy3: pypy3
 deps=
     pytest
-    1.8: Django>=1.8,<1.9
-    1.9: Django>=1.9,<1.10
-    1.10: Django>=1.10,<1.11
-    1.11: Django>=1.11,<1.12
-    2.0: Django>=2.0,<2.1
-    2.1: Django>=2.1,<2.2
-    2.2: Django>=2.2,<2.3
-    3.0: Django>=3.0,<3.1
-    master: https://github.com/django/django/archive/master.tar.gz
+    2.2.x: Django>=2.2,<2.3
+    3.0.x: Django>=3.0,<3.1
+    main: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
* Remove old Django and Python versions from tox and Circle CI test grids
* Update setup.py classifiers accordingly.
* Update `py.test` command to `pytest` since it was renamed.
* Update `master` to `main` for Django's default branch since it was renamed.
* Drop universal wheel declaration in `setup.cfg` since Python 2 is no longer supported.
* Fix `.gitignore` to ignore generated coverage files.
* Move `pytest-cov` requirement to test requirements to get a version compatible with the pinned pytest version (otherwise pip logs a red warning).