### PR TITLE
add project_urls to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,12 @@ setup(
     url='http://github.com/mozilla/django-csp',
     license='BSD',
     packages=find_packages(),
+    project_urls={
+        "Documentation": "http://django-csp.readthedocs.org/",
+        "Changelog": "https://github.com/mozilla/django-csp/blob/master/CHANGES",
+        "Bug Tracker": "https://github.com/mozilla/django-csp/issues",
+        "Source Code": "https://github.com/mozilla/django-csp",
+    },
     install_requires=install_requires,
     extras_require={
         'tests': test_requires,


### PR DESCRIPTION
This PR adds a `project_urls` section to setup.py that will make important links appear on the left hand side of pypi for docs, changelog, bug tracking, and source code.

Here's an example of how it looks on the attrs project:
<img width="300" alt="Screen Shot 2021-05-07 at 7 15 54 PM" src="https://user-images.githubusercontent.com/992533/117520249-ce896c80-af96-11eb-94ad-9ec7d63d3301.png">

More details about `project_urls`: https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls
