### PR TITLE
rename default branch

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,9 @@ Next
 ====
 
 - Remove deprecation warning for child-src
-=======
+- Add project urls to setup.py
+- Drop support for EOL Python <3.6 and Django <2.2 versions
+- Rename default branch to main
 
 3.7
 ===

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
 .. image:: https://badge.fury.io/py/django-csp.svg
    :target: https://pypi.python.org/pypi/django_csp
 
-.. image:: https://travis-ci.org/mozilla/django-csp.svg?branch=master
+.. image:: https://travis-ci.org/mozilla/django-csp.svg?branch=main
    :target: https://travis-ci.org/mozilla/django-csp
 
-.. image:: https://coveralls.io/repos/github/mozilla/django-csp/badge.svg?branch=master
-   :target: https://coveralls.io/github/mozilla/django-csp?branch=master
+.. image:: https://coveralls.io/repos/github/mozilla/django-csp/badge.svg?branch=main
+   :target: https://coveralls.io/github/mozilla/django-csp?branch=main
 
 ==========
 Django-CSP

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     packages=find_packages(),
     project_urls={
         "Documentation": "http://django-csp.readthedocs.org/",
-        "Changelog": "https://github.com/mozilla/django-csp/blob/master/CHANGES",
+        "Changelog": "https://github.com/mozilla/django-csp/blob/main/CHANGES",
         "Bug Tracker": "https://github.com/mozilla/django-csp/issues",
         "Source Code": "https://github.com/mozilla/django-csp",
     },


### PR DESCRIPTION
Changes:
* rename the default branch to `main` (we might need to update RTD config)