### PR TITLE
fix unwrap script re

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Next
 - Add project urls to setup.py
 - Drop support for EOL Python <3.6 and Django <2.2 versions
 - Rename default branch to main
+- Fix capturing brackets in script template tags
 
 3.7
 ===

--- a/csp/tests/test_jinja_extension.py
+++ b/csp/tests/test_jinja_extension.py
@@ -77,3 +77,22 @@ class TestJinjaExtension(ScriptExtensionTestBase):
             'var hello=\'world\';</script>')
 
         self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_regex_captures_script_content_including_brackets(self):
+        """
+        Ensure that script content get captured properly.
+        Especially when using angle brackets."""
+        tpl = """
+            {% script %}
+            <script type="text/javascript">
+                let capture_text = "<script></script>"
+            </script>
+            {% endscript %}
+            """
+
+        expected = (
+            '<script nonce="{}">'
+            'let capture_text = "<script></script>"'
+            '</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))

--- a/csp/tests/test_templatetags.py
+++ b/csp/tests/test_templatetags.py
@@ -76,3 +76,23 @@ class TestDjangoTemplateTag(ScriptTagTestBase):
             'var hello=\'world\';</script>')
 
         self.assert_template_eq(*self.process_templates(tpl, expected))
+
+    def test_regex_captures_script_content_including_brackets(self):
+        """
+        Ensure that script content get captured properly.
+        Especially when using angle brackets."""
+        tpl = """
+            {% load csp %}
+            {% script %}
+            <script type="text/javascript">
+                let capture_text = "<script></script>"
+            </script>
+            {% endscript %}
+            """
+
+        expected = (
+            '<script nonce="{}">'
+            'let capture_text = "<script></script>"'
+            '</script>')
+
+        self.assert_template_eq(*self.process_templates(tpl, expected))

--- a/csp/tests/utils.py
+++ b/csp/tests/utils.py
@@ -24,7 +24,7 @@ class ScriptTestBase(object):
     def assert_template_eq(self, tpl1, tpl2):
         aaa = tpl1.replace('\n', '').replace('  ', '')
         bbb = tpl2.replace('\n', '').replace('  ', '')
-        assert aaa == bbb
+        assert aaa == bbb, "{} != {}".format(aaa, bbb)
 
     def process_templates(self, tpl, expected):
         request = rf.get('/')

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -155,9 +155,19 @@ SCRIPT_ATTRS['nomodule'] = _bool_attr_mapper
 ATTR_FORMAT_STR = ''.join(['{{{}}}'.format(a) for a in SCRIPT_ATTRS])
 
 
+_script_tag_contents_re = re.compile(
+    r"""<script        # match the opening script tag
+            [\s|\S]*?> # minimally match attrs and spaces in opening script tag
+    ([\s|\S]+)         # greedily capture the script tag contents
+    </script>          # match the closing script tag
+""",
+    re.VERBOSE,
+)
+
+
 def _unwrap_script(text):
     """Extract content defined between script tags"""
-    matches = re.search(r'<script[\s|\S]*>([\s|\S]+?)</script>', text)
+    matches = re.search(_script_tag_contents_re, text)
     if matches and len(matches.groups()):
         return matches.group(1).strip()
 

--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -42,13 +42,32 @@ This library contains an optional context processor, adding ``csp.context_proces
 
 .. note::
 
-    If you're making use of ``csp.extensions.NoncedScript`` you need to have ``jinja2>=2.9.6`` installed, so please make sure to either use ``django-csp[jinja2]`` in your requirements or define it yourself.
+   If you're making use of ``csp.extensions.NoncedScript`` you need to have ``jinja2>=2.9.6`` installed, so please make sure to either use ``django-csp[jinja2]`` in your requirements or define it yourself.
 
-Since it can be easy to forget to include the ``nonce`` property in a script tag, there is also a ``script`` template tag available for both Django templates and Jinja environments.
+
+It can be easy to forget to include the ``nonce`` property in a script tag, so there is also a ``script`` template tag available for both Django templates and Jinja environments.
 
 This tag will output a properly nonced script every time. For the sake of syntax highlighting, you can wrap the content inside of the ``script`` tag in ``<script>`` html tags, which will be subsequently removed in the rendered output. Any valid script tag attributes can be specified and will be forwarded into the rendered html.
 
-Django:
+
+Django Templates
+----------------
+
+Add the CSP template tags to the TEMPLATES section of your settings file:
+
+.. code-block:: python
+
+	TEMPLATES = [
+	    {
+		"OPTIONS": {
+		    'libraries':          {
+			'csp': 'csp.templatetags.csp',
+		    }
+		},
+	    }
+	]
+
+Then load the ``csp`` template tags and use ``script`` in the template:
 
 .. code-block:: jinja
 
@@ -60,9 +79,24 @@ Django:
 	{% endscript %}
 
 
-Jinja:
+Jinja
+-----
 
-(assumes ``csp.extensions.NoncedScript`` is added to the jinja extensions setting)
+Add ``csp.extensions.NoncedScript`` to the TEMPLATES section of your settings file:
+
+.. code-block:: python
+
+          TEMPLATES = [
+              {
+                  'BACKEND':'django.template.backends.jinja2.Jinja2',
+                  'OPTIONS': {
+                      'extensions': [
+                          'csp.extensions.NoncedScript',
+                      ],
+                  }
+             }
+          ]
+
 
 .. code-block:: jinja
 
@@ -72,9 +106,9 @@ Jinja:
 		</script>
 	{% endscript %}
 
-Will output -
+
+Both templates output the following with a different nonce:
 
 .. code-block:: html
 
 	<script nonce='123456' type="application/javascript" async=false>var hello='world';</script>
-


### PR DESCRIPTION
Rebased #161 with a few updates

Overall changes:
* update the template tag unwrap regex to capture open and close brackets (from #161 was originally in #155)
* compile the script tag capturing regex
* print the non-equal templates from the `assert_template_eq` test helper
* update docs
