### PR TITLE
updating csp_replace decorator doc

### DIFF
--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -69,6 +69,7 @@ or tuples.
 The ``@csp_replace`` decorator allows you to **replace** a source list
 specified in settings. If there is no setting, the value passed to the
 decorator will be used verbatim. (See the note under ``@csp_update``.)
+If the specified value is None, the corresponding key will not be included.
 
 The arguments and values are the same as ``@csp_update``::
 


### PR DESCRIPTION
The doc does not indicate csp_replace with value of None will not include the corresponding key in the csp. I didn't know this behavior existed, wrote a decorator for delete and found the behavior i wanted already exists in the test for csp_replace. 