### PR TITLE
Remove outdated docs reference to MIDDLEWARE_CLASSES

### DIFF
--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -20,7 +20,7 @@ Installing the middleware creates a lazily evaluated property ``csp_nonce`` and 
 
 .. code-block:: python
 
-	MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
     	#...
     	'csp.middleware.CSPMiddleware',
     	#...


### PR DESCRIPTION
`MIDDLEWARE_CLASSES` was removed in django 2.0, `MIDDLEWARE` is the new django setting name.