### PR TITLE
Remove package six 

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -7,11 +7,7 @@ from functools import partial
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 
-try:
-    from django.utils.six.moves import http_client
-except ImportError:
-    # django 3.x removed six
-    import http.client as http_client
+import http.client as http_client
 
 try:
     from django.utils.deprecation import MiddlewareMixin

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import six
 from django.conf import settings
 from django.test.utils import override_settings
 from django.utils.functional import lazy
@@ -23,7 +22,7 @@ def literal(s):
     return s
 
 
-lazy_literal = lazy(literal, six.text_type)
+lazy_literal = lazy(literal, str)
 
 
 @override_settings(CSP_DEFAULT_SRC=['example.com', 'example2.com'])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ test_requires = [
     'pytest-pep8==1.0.6',
     'pep8==1.4.6',
     'mock==1.0.1',
-    'six==1.12.0',
 ]
 
 test_requires += jinja2_requires


### PR DESCRIPTION
`six` is no longer required in Python 3