### PR TITLE
Wrap the test install with quotes.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -26,7 +26,7 @@ test those features thoroughly.
 To run the tests, install the requirements (probably into a virtualenv_)::
 
     pip install -e .
-    pip install -e .[tests]
+    pip install -e ".[tests]"
 
 Then just `py.test`_ to run the tests::
 


### PR DESCRIPTION
`pip install -e .[tests]` fails with `.tests is not a valid editable requirement`