### PR TITLE
MiddlewareMixin is always present in django>=3.2

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -6,20 +6,8 @@ import os
 from functools import partial
 
 from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
-
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-
-    class MiddlewareMixin(object):
-        """
-        If this middleware doesn't exist, this is an older version of django
-        and we don't need it.
-        """
-
-        pass
-
 
 from csp.utils import build_policy
 


### PR DESCRIPTION
it was added in django 2.0a1 https://github.com/django/django/commit/cecc079168e8669138728d31611ff3a1e7eb3a9f