### PR TITLE
Bring codebase up to modern Python using pyupgrade

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Next
 Unreleased
 ==========
 
+- Update Python syntax for modern versions with pyupgrade
 - Drop support for EOL Python <3.8 and Django <2.2 versions
 - Switch to ruff instead of pep8 and flake8
 - Move from CircleCI to Github Actions for CI

--- a/csp/decorators.py
+++ b/csp/decorators.py
@@ -12,7 +12,7 @@ def csp_exempt(f):
 
 
 def csp_update(**kwargs):
-    update = dict((k.lower().replace("_", "-"), v) for k, v in kwargs.items())
+    update = {k.lower().replace("_", "-"): v for k, v in kwargs.items()}
 
     def decorator(f):
         @wraps(f)
@@ -27,7 +27,7 @@ def csp_update(**kwargs):
 
 
 def csp_replace(**kwargs):
-    replace = dict((k.lower().replace("_", "-"), v) for k, v in kwargs.items())
+    replace = {k.lower().replace("_", "-"): v for k, v in kwargs.items()}
 
     def decorator(f):
         @wraps(f)
@@ -42,7 +42,7 @@ def csp_replace(**kwargs):
 
 
 def csp(**kwargs):
-    config = dict((k.lower().replace("_", "-"), [v] if isinstance(v, str) else v) for k, v in kwargs.items())
+    config = {k.lower().replace("_", "-"): [v] if isinstance(v, str) else v for k, v in kwargs.items()}
 
     def decorator(f):
         @wraps(f)

--- a/csp/extensions/__init__.py
+++ b/csp/extensions/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from jinja2 import nodes
 from jinja2.ext import Extension
 

--- a/csp/extensions/__init__.py
+++ b/csp/extensions/__init__.py
@@ -6,7 +6,7 @@ from csp.utils import SCRIPT_ATTRS, build_script_tag
 
 class NoncedScript(Extension):
     # a set of names that trigger the extension.
-    tags = set(["script"])
+    tags = {"script"}
 
     def parse(self, parser):
         # the first token is the token that started the tag.  In our case

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import base64
 import http.client as http_client
 import os

--- a/csp/templatetags/csp.py
+++ b/csp/templatetags/csp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django import template
 from django.template.base import token_kwargs
 

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.conf import settings
 from django.test.utils import override_settings
 from django.utils.functional import lazy

--- a/csp/tests/utils.py
+++ b/csp/tests/utils.py
@@ -25,7 +25,7 @@ class ScriptTestBase(object):
     def assert_template_eq(self, tpl1, tpl2):
         aaa = tpl1.replace("\n", "").replace("  ", "")
         bbb = tpl2.replace("\n", "").replace("  ", "")
-        assert aaa == bbb, "{} != {}".format(aaa, bbb)
+        assert aaa == bbb, f"{aaa} != {bbb}"
 
     def process_templates(self, tpl, expected):
         request = rf.get("/")

--- a/csp/tests/utils.py
+++ b/csp/tests/utils.py
@@ -21,7 +21,7 @@ mw = CSPMiddleware(response())
 rf = RequestFactory()
 
 
-class ScriptTestBase(object):
+class ScriptTestBase:
     def assert_template_eq(self, tpl1, tpl2):
         aaa = tpl1.replace("\n", "").replace("  ", "")
         bbb = tpl2.replace("\n", "").replace("  ", "")

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -99,7 +99,7 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
         include_nonce_in = getattr(settings, "CSP_INCLUDE_NONCE_IN", ["default-src"])
         for section in include_nonce_in:
             policy = policy_parts.get(section, "")
-            policy_parts[section] = ("%s %s" % (policy, "'nonce-%s'" % nonce)).strip()
+            policy_parts[section] = ("{} {}".format(policy, "'nonce-%s'" % nonce)).strip()
 
     return "; ".join([f"{k} {val}".strip() for k, val in policy_parts.items()])
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -101,12 +101,12 @@ def build_policy(config=None, update=None, replace=None, nonce=None):
             policy = policy_parts.get(section, "")
             policy_parts[section] = ("%s %s" % (policy, "'nonce-%s'" % nonce)).strip()
 
-    return "; ".join(["{} {}".format(k, val).strip() for k, val in policy_parts.items()])
+    return "; ".join([f"{k} {val}".strip() for k, val in policy_parts.items()])
 
 
 def _default_attr_mapper(attr_name, val):
     if val:
-        return ' {}="{}"'.format(attr_name, val)
+        return f' {attr_name}="{val}"'
     else:
         return ""
 
@@ -115,7 +115,7 @@ def _bool_attr_mapper(attr_name, val):
     # Only return the bare word if the value is truthy
     # ie - defer=False should actually return an empty string
     if val:
-        return " {}".format(attr_name)
+        return f" {attr_name}"
     else:
         return ""
 
@@ -125,9 +125,9 @@ def _async_attr_mapper(attr_name, val):
     attributes. It can be set explicitly to `false` with no surrounding quotes
     according to the spec."""
     if val in [False, "False"]:
-        return " {}=false".format(attr_name)
+        return f" {attr_name}=false"
     elif val:
-        return " {}".format(attr_name)
+        return f" {attr_name}"
     else:
         return ""
 
@@ -144,7 +144,7 @@ SCRIPT_ATTRS["integrity"] = _default_attr_mapper
 SCRIPT_ATTRS["nomodule"] = _bool_attr_mapper
 
 # Generates an interpolatable string of valid attrs eg - '{nonce}{id}...'
-ATTR_FORMAT_STR = "".join(["{{{}}}".format(a) for a in SCRIPT_ATTRS])
+ATTR_FORMAT_STR = "".join([f"{{{a}}}" for a in SCRIPT_ATTRS])
 
 
 _script_tag_contents_re = re.compile(
@@ -176,4 +176,4 @@ def build_script_tag(content=None, **kwargs):
     # Don't render block contents if the script has a 'src' attribute
     c = _unwrap_script(content) if content and not kwargs.get("src") else ""
     attrs = ATTR_FORMAT_STR.format(**data).rstrip()
-    return "<script{}>{}</script>".format(attrs, c).strip()
+    return f"<script{attrs}>{c}</script>".strip()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Django-CSP documentation build configuration file, created by
 # sphinx-quickstart on Wed Oct 31 13:02:27 2012.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
     os.system("python setup.py bdist_wheel upload")
     print("You probably want to also tag the version now:")
-    print('  git tag -a %s -m "version %s"' % (version, version))
+    print(f'  git tag -a {version} -m "version {version}"')
     print("  git push --tags")
     sys.exit()
 


### PR DESCRIPTION
This changeset tweaks some things flagged (and auto-fixed) by pyupgrade, targetting 3.12. Tox confirms things still work all the back back to 3.8

(Note: we still need to/should follow up with an actual close-up code review of it all, too. `django-upgrade` didn't spot anything that needed fixing, which kind of surprised me)