### PR TITLE
Add constants for CSP keywords

### DIFF
--- a/csp/constants.py
+++ b/csp/constants.py
@@ -1,2 +1,12 @@
 HEADER = "Content-Security-Policy"
 HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only"
+
+NONE = "'none'"
+REPORT_SAMPLE = "'report-sample'"
+SELF = "'self'"
+STRICT_DYNAMIC = "'strict-dynamic'"
+UNSAFE_ALLOW_REDIRECTS = "'unsafe-allow-redirects'"
+UNSAFE_EVAL = "'unsafe-eval'"
+UNSAFE_HASHES = "'unsafe-hashes'"
+UNSAFE_INLINE = "'unsafe-inline'"
+WASM_UNSAFE_EVAL = "'wasm-unsafe-eval'"

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -6,7 +6,7 @@ from django.http import (
 from django.test import RequestFactory
 from django.test.utils import override_settings
 
-from csp.constants import HEADER, HEADER_REPORT_ONLY
+from csp.constants import HEADER, HEADER_REPORT_ONLY, SELF
 from csp.middleware import CSPMiddleware
 from csp.tests.utils import response
 
@@ -23,7 +23,7 @@ def test_add_header():
 
 @override_settings(
     CONTENT_SECURITY_POLICY={"DIRECTIVES": {"default-src": ["example.com"]}},
-    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": ["'self'"]}},
+    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": [SELF]}},
 )
 def test_both_headers():
     request = rf.get("/")
@@ -51,7 +51,7 @@ def text_exclude():
 
 @override_settings(
     CONTENT_SECURITY_POLICY=None,
-    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": ["'self'"]}},
+    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": [SELF]}},
 )
 def test_report_only():
     request = rf.get("/")

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -1,6 +1,7 @@
 from django.test.utils import override_settings
 from django.utils.functional import lazy
 
+from csp.constants import NONE, SELF
 from csp.utils import build_policy, default_config, DEFAULT_DIRECTIVES
 
 
@@ -182,7 +183,7 @@ def test_replace_missing_setting():
 
 
 def test_config():
-    policy = build_policy(config={"default-src": ["'none'"], "img-src": ["'self'"]})
+    policy = build_policy(config={"default-src": [NONE], "img-src": [SELF]})
     policy_eq("default-src 'none'; img-src 'self'", policy)
 
 

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -6,12 +6,13 @@ from itertools import chain
 from django.conf import settings
 from django.utils.encoding import force_str
 
+from csp.constants import SELF
 
 DEFAULT_DIRECTIVES = {
     # Fetch Directives
     "child-src": None,
     "connect-src": None,
-    "default-src": ["'self'"],
+    "default-src": [SELF],
     "script-src": None,
     "script-src-attr": None,
     "script-src-elem": None,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -25,16 +25,22 @@ Patches fixing bugs should include regression tests (ideally tests that
 fail without the rest of the patch). Patches adding new features should
 test those features thoroughly.
 
-To run the tests, install the requirements (probably into a virtualenv_)::
+To run the tests, install the requirements (probably into a virtualenv_):
+
+.. code-block:: bash
 
     pip install -e .
     pip install -e ".[tests]"
 
-Then just `pytest`_ to run the tests::
+Then just `pytest`_ to run the tests:
+
+.. code-block:: bash
 
     pytest
 
-To run the tests with coverage and get a report, use the following command::
+To run the tests with coverage and get a report, use the following command:
+
+.. code-block:: bash
 
     pytest --cov=csp --cov-config=.coveragerc
 


### PR DESCRIPTION
This helps avoid potential errors introduced by incorrectly quoting CSP keywords.