### PR TITLE
Use simple logical operator in middleware

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -57,7 +57,7 @@ class CSPMiddleware(MiddlewareMixin):
             policy = getattr(settings, "CONTENT_SECURITY_POLICY", None) or {}
             prefixes = policy.get("EXCLUDE_URL_PREFIXES", None) or ()
             is_not_excluded = not request.path_info.startswith(tuple(prefixes))
-            if all((no_header, is_not_exempt, is_not_excluded)):
+            if no_header and is_not_exempt and is_not_excluded:
                 response[HEADER] = csp
 
         csp_ro = self.build_policy_ro(request, response)
@@ -68,7 +68,7 @@ class CSPMiddleware(MiddlewareMixin):
             policy = getattr(settings, "CONTENT_SECURITY_POLICY_REPORT_ONLY", None) or {}
             prefixes = policy.get("EXCLUDE_URL_PREFIXES", None) or ()
             is_not_excluded = not request.path_info.startswith(tuple(prefixes))
-            if all((no_header, is_not_exempt, is_not_excluded)):
+            if no_header and is_not_exempt and is_not_excluded:
                 response[HEADER_REPORT_ONLY] = csp_ro
 
         return response


### PR DESCRIPTION
The usage of [`all`](https://docs.python.org/3.10/library/functions.html#all) is an overengineering of what can be handled with a simple sequence of `and`.

Also since `all` is a function which requires an iterable as the only argument it is much slower than a simple logical operator.