### PR TITLE
Update tox.ini for Django 3.2, pypy, github actions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,13 @@ basepython =
     3.10: python3.10
     3.11: python3.11
     3.12: python3.12
-    pypy3: pypy3
+    pypy38: pypy3.8
+    pypy39: pypy3.9
+    pypy310: pypy3.10
 
 deps =
     pytest
+    3.2.x: Django>=3.2,<3.3
     4.2.x: Django>=4.2,<4.3
     5.0.x: Django>=5.0.1,<5.1
     main: https://github.com/django/django/archive/main.tar.gz
@@ -45,11 +48,11 @@ deps =
 # Running tox in GHA without redefining it all in a GHA matrix:
 # https://github.com/ymyzk/tox-gh-actions
 python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
+    3.8: 3.8
+    3.9: 3.9
+    3.10: 3.10
+    3.11: 3.11
+    3.12: 3.12
     pypy-3.8: pypy38
     pypy-3.9: pypy39
     pypy-3.10: pypy310

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@ envlist =
     {3.10,3.11,3.12,pypy310}-main
     {3.10,3.11,3.12,pypy310}-5.0.x
     {3.8,3.9,3.10,3.11,3.12,pypy38,pypy39,pypy310}-4.2.x
-    {3.8,3.9,3.10,pypy38,pypy39,pypy310}-3.2.x
+    {3.8,3.9,3.10}-3.2.x
 
 
 # Don't run coverage when testing with pypy:
 # see https://github.com/nedbat/coveragepy/issues/1382
-[testenv:pypy310-main,pypy310-5.0.x,{pypy38,pypy39,pypy310}-4.2.x,{pypy38,pypy39,pypy310}-3.2.x]
+[testenv:pypy310-main,pypy310-5.0.x,{pypy38,pypy39,pypy310}-4.2.x]
 commands =
     pip install --upgrade pip
     pip install -e .[tests]


### PR DESCRIPTION
This PR specifies how to install Django 3.2. Before this change, when a test is supposed to run against Django 3.2, it instead runs against the latest release.

This PR adds `basepython` entries for `pypy`. This fixes running these test locally.

This PR fixes cpython version mapping in `[gh-actions]` (like 3.8, 3.9, etc.). Previously, the github action tests for cpython versions were running against the latest Django, instead of all possible Django versions.

This PR drops testing pypy against Django 3.2. There are a few errors that appear:

```
_____________________________________________ test_report_percentage_report_only _____________________________________________
csp/tests/test_contrib.py:33: in test_report_percentage_report_only
    if "report-uri" in response[HEADER_REPORT_ONLY]:
.tox/pypy38-3.2.x/lib/pypy3.8/site-packages/django/http/response.py:178: in __getitem__
    return self.headers[header]
.tox/pypy38-3.2.x/lib/pypy3.8/site-packages/django/utils/datastructures.py:316: in __getitem__
    return self._store[key.lower()][1]
E   KeyError: 'content-security-policy-report-only'
______________________________________________________ test_csp_update _______________________________________________________
csp/tests/test_decorators.py:58: in test_csp_update
    assert policy_list == ["default-src 'self'", f"img-src foo.com bar.com 'nonce-{request.csp_nonce}'"]
E   assert ["default-src...report-uri x'] == ["default-src...OlDPT/I0w=='"]
E     
E     At index 1 diff: "img-src bar.com 'nonce-RTVrw2N3wZNaaOlDPT/I0w=='" != "img-src foo.com bar.com 'nonce-RTVrw2N3wZNaaOlDPT/I0w=='"
E     Left contains one more item: 'report-uri x'
E     
E     Full diff:
E       [
E           "default-src 'self'",...
E     
E     ...Full output truncated (5 lines hidden), use '-vv' to show
______________________________________________________ test_csp_replace ______________________________________________________
csp/tests/test_decorators.py:122: in test_csp_replace
    assert policy_list == ["default-src 'self'", "img-src bar.com"]
E   assert ["default-src...report-uri x'] == ["default-src...-src bar.com']
E     
E     Left contains one more item: 'report-uri x'
E     
E     Full diff:
E       [
E           "default-src 'self'",
E           'img-src bar.com',
E     +     'report-uri x',
E       ]
```

This appears to be issue with `pypy` dictionary implementations. Sometimes the header doesn't appear, and sometimes a dictionary value is retained across tests. Rather than debug this, I decided to drop them for this Django version that is no longer supported.
