### PR TITLE
Fix #231: report percentage of 100% should always report

### DIFF
--- a/csp/contrib/rate_limiting.py
+++ b/csp/contrib/rate_limiting.py
@@ -28,9 +28,14 @@ class RateLimitedCSPMiddleware(CSPMiddleware):
             return ""
 
         report_percentage = policy.get("REPORT_PERCENTAGE", 100)
-        include_report_uri = random.randint(0, 100) < report_percentage
-        if not include_report_uri:
-            replace["report-uri"] = None
+        remove_report = random.randint(0, 99) >= report_percentage
+        if remove_report:
+            replace.update(
+                {
+                    "report-uri": None,
+                    "report-to": None,
+                }
+            )
 
         return build_policy(config=config, update=update, replace=replace, nonce=nonce)
 
@@ -46,8 +51,13 @@ class RateLimitedCSPMiddleware(CSPMiddleware):
             return ""
 
         report_percentage = policy.get("REPORT_PERCENTAGE", 100)
-        include_report_uri = random.randint(0, 100) < report_percentage
-        if not include_report_uri:
-            replace["report-uri"] = None
+        remove_report = random.randint(0, 99) >= report_percentage
+        if remove_report:
+            replace.update(
+                {
+                    "report-uri": None,
+                    "report-to": None,
+                }
+            )
 
         return build_policy(config=config, update=update, replace=replace, nonce=nonce, report_only=True)

--- a/csp/tests/test_contrib.py
+++ b/csp/tests/test_contrib.py
@@ -19,8 +19,24 @@ def test_report_percentage() -> None:
         mw.process_response(request, response)
         if "report-uri" in response[HEADER]:
             times_seen += 1
+        if "report-to" in response[HEADER]:
+            times_seen += 1
     # Roughly 10%
     assert 400 <= times_seen <= 600
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"REPORT_PERCENTAGE": 100, "DIRECTIVES": {"report-uri": "x"}})
+def test_report_percentage_100() -> None:
+    times_seen = 0
+    for _ in range(1000):
+        request = rf.get("/")
+        response = HttpResponse()
+        mw.process_response(request, response)
+        if "report-uri" in response[HEADER]:
+            times_seen += 1
+        if "report-to" in response[HEADER]:
+            times_seen += 1
+    assert times_seen == 1000
 
 
 @override_settings(CONTENT_SECURITY_POLICY_REPORT_ONLY={"REPORT_PERCENTAGE": 10, "DIRECTIVES": {"report-uri": "x"}})


### PR DESCRIPTION
This also updates the RateLimited CSPMiddleware to remove both `report-uri` and `report-to` directives based on report percentage.