### PR TITLE
refactor(middleware): Refactor internals of CSPMiddleware so that it's easier to extend existing logic without copy/pasting it into subclass

### DIFF
--- a/csp/utils.py
+++ b/csp/utils.py
@@ -52,10 +52,10 @@ DEFAULT_DIRECTIVES = {
     "block-all-mixed-content": None,  # Deprecated.
 }
 
-_DIRECTIVES = Dict[str, Any]
+DIRECTIVES_T = Dict[str, Any]
 
 
-def default_config(csp: _DIRECTIVES | None) -> _DIRECTIVES | None:
+def default_config(csp: DIRECTIVES_T | None) -> DIRECTIVES_T | None:
     if csp is None:
         return None
     # Make a copy of the passed in config to avoid mutating it, and also to drop any unknown keys.
@@ -66,9 +66,9 @@ def default_config(csp: _DIRECTIVES | None) -> _DIRECTIVES | None:
 
 
 def build_policy(
-    config: _DIRECTIVES | None = None,
-    update: _DIRECTIVES | None = None,
-    replace: _DIRECTIVES | None = None,
+    config: DIRECTIVES_T | None = None,
+    update: DIRECTIVES_T | None = None,
+    replace: DIRECTIVES_T | None = None,
     nonce: str | None = None,
     report_only: bool = False,
 ) -> str:


### PR DESCRIPTION
The current implementation of `csp.middleware.CSPMiddleware` doesn't lend itself to extending the functionality of it or the `csp.contrib.rate_limiting.RateLimitedCSPMiddleware` without copy/pasting the implementation of `.build_policy()` and `.build_policy_ro()`

This is a bit of an issue, because it means any updates to the base implementation of the superclass has to be manually copied into any subclasses.

For example, for my multi-tenant webapp project, we use the `RateLimitedCSPMiddleware` and have an additional requirement to generate a CSP that contains some per-tenant configuration. So I've created a custom middleware by copying the code from `RateLimitedCSPMiddleware` and adding my extra logic in.

This isn't great because if the implementation of `RateLimitedCSPMiddleware` changes, for example to fix this issue https://github.com/mozilla/django-csp/issues/231, then I have to remember to check for changes and manually copy them into my middleware.

So, I'm proposing a change to how CSPMiddleware works to provide a better hook into the existing implementation and allow subclasses to modify things before the policy string is built.

As you can see from the diff, this reduces the lines of code required to create a CSPMiddleware subclass, even more so when extending the `RateLimitedCSPMiddleware`.

The `build_policy` and `build_policy_ro` methods are essentially redundant with this PR, but I wasn't too sure about removing  outright, since it would a breaking change, so would like the maintainers' input on that.

Finally, I haven't attempted to address any of the known issues already raised in other issues/PRs