### PR TITLE
fix: support CSP configuration as sets

### DIFF
--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -33,6 +33,18 @@ def test_both_headers() -> None:
     assert HEADER_REPORT_ONLY in response
 
 
+@override_settings(
+    CONTENT_SECURITY_POLICY={"DIRECTIVES": {"default-src": {"example.com"}}},
+    CONTENT_SECURITY_POLICY_REPORT_ONLY={"DIRECTIVES": {"default-src": {SELF}}},
+)
+def test_directives_configured_as_sets() -> None:
+    request = rf.get("/")
+    response = HttpResponse()
+    mw.process_response(request, response)
+    assert HEADER in response
+    assert HEADER_REPORT_ONLY in response
+
+
 def test_exempt() -> None:
     request = rf.get("/")
     response = HttpResponse()

--- a/csp/tests/test_templatetags.py
+++ b/csp/tests/test_templatetags.py
@@ -39,7 +39,7 @@ class TestDjangoTemplateTag(ScriptTagTestBase):
             {% script src="foo.com/bar.js" async=False %}
             {% endscript %}"""
 
-        expected = '<script nonce="{}" src="foo.com/bar.js" async=false>' "</script>"
+        expected = '<script nonce="{}" src="foo.com/bar.js" async=false></script>'
 
         self.assert_template_eq(*self.process_templates(tpl, expected))
 

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -55,6 +55,11 @@ def test_default_src() -> None:
     policy = build_policy()
     policy_eq("default-src example.com example2.com", policy)
 
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"default-src": {"example.com", "example2.com"}}})
+def test_default_src_is_set() -> None:
+    policy = build_policy()
+    policy_eq("default-src example.com example2.com", policy)
+
 
 @override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"script-src": ["example.com"]}})
 def test_script_src() -> None:
@@ -209,6 +214,25 @@ def test_replace_string() -> None:
     Demonstrate that GitHub issue #40 doesn't affect replacements
     """
     policy = build_policy(replace={"img-src": "example2.com"})
+    policy_eq("default-src 'self'; img-src example2.com", policy)
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"img-src": ("example.com",)}})
+def test_update_set() -> None:
+    """
+    GitHub issue #40 - given project settings as a tuple, and
+    an update/replace with a string, concatenate correctly.
+    """
+    policy = build_policy(update={"img-src": {"example2.com"}})
+    policy_eq("default-src 'self'; img-src example.com example2.com", policy)
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"img-src": ("example.com",)}})
+def test_replace_set() -> None:
+    """
+    Demonstrate that GitHub issue #40 doesn't affect replacements
+    """
+    policy = build_policy(replace={"img-src": {"example2.com"}})
     policy_eq("default-src 'self'; img-src example2.com", policy)
 
 

--- a/csp/tests/test_utils.py
+++ b/csp/tests/test_utils.py
@@ -55,6 +55,7 @@ def test_default_src() -> None:
     policy = build_policy()
     policy_eq("default-src example.com example2.com", policy)
 
+
 @override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"default-src": {"example.com", "example2.com"}}})
 def test_default_src_is_set() -> None:
     policy = build_policy()
@@ -335,6 +336,35 @@ def test_nonce_in_value() -> None:
 def test_only_nonce_in_value() -> None:
     policy = build_policy(nonce="abc123")
     policy_eq("default-src 'nonce-abc123'", policy)
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"img-src": ["example.com", "example.com"]}})
+def test_deduplicate_values() -> None:
+    """
+    GitHub issue #40 - given project settings as a tuple, and
+    an update/replace with a string, concatenate correctly.
+    """
+    policy = build_policy()
+    policy_eq("default-src 'self'; img-src example.com", policy)
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"img-src": ["example.com", "example.com"]}})
+def test_deduplicate_values_update() -> None:
+    """
+    GitHub issue #40 - given project settings as a tuple, and
+    an update/replace with a string, concatenate correctly.
+    """
+    policy = build_policy(update={"img-src": "example.com"})
+    policy_eq("default-src 'self'; img-src example.com", policy)
+
+
+@override_settings(CONTENT_SECURITY_POLICY={"DIRECTIVES": {"img-src": ("example.com",)}})
+def test_deduplicate_values_replace() -> None:
+    """
+    Demonstrate that GitHub issue #40 doesn't affect replacements
+    """
+    policy = build_policy(replace={"img-src": ["example2.com", "example2.com"]})
+    policy_eq("default-src 'self'; img-src example2.com", policy)
 
 
 def test_boolean_directives() -> None:

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -98,13 +98,13 @@ def build_policy(
             v = config[k]
         if v is not None:
             v = copy.copy(v)
-            if not isinstance(v, (list, tuple)):
+            if not isinstance(v, (list, tuple, set)):
                 v = (v,)
             csp[k] = v
 
     for k, v in update.items():
         if v is not None:
-            if not isinstance(v, (list, tuple)):
+            if not isinstance(v, (list, tuple, set)):
                 v = (v,)
             if csp.get(k) is None:
                 csp[k] = v
@@ -117,10 +117,12 @@ def build_policy(
 
     for key, value in csp.items():
         # Check for boolean directives.
-        if len(value) == 1 and isinstance(value[0], bool):
-            if value[0] is True:
-                policy_parts[key] = ""
-            continue
+        if len(value) == 1:
+            val = list(value)[0]
+            if isinstance(val, bool):
+                if value[0] is True:
+                    policy_parts[key] = ""
+                continue
         if NONCE in value:
             if nonce:
                 value = [f"'nonce-{nonce}'" if v == NONCE else v for v in value]

--- a/csp/utils.py
+++ b/csp/utils.py
@@ -98,13 +98,18 @@ def build_policy(
             v = config[k]
         if v is not None:
             v = copy.copy(v)
-            if not isinstance(v, (list, tuple, set)):
+            if isinstance(v, set):
+                v = sorted(v)
+            if not isinstance(v, (list, tuple)):
                 v = (v,)
             csp[k] = v
 
     for k, v in update.items():
         if v is not None:
-            if not isinstance(v, (list, tuple, set)):
+            v = copy.copy(v)
+            if isinstance(v, set):
+                v = sorted(v)
+            if not isinstance(v, (list, tuple)):
                 v = (v,)
             if csp.get(k) is None:
                 csp[k] = v
@@ -117,12 +122,10 @@ def build_policy(
 
     for key, value in csp.items():
         # Check for boolean directives.
-        if len(value) == 1:
-            val = list(value)[0]
-            if isinstance(val, bool):
-                if value[0] is True:
-                    policy_parts[key] = ""
-                continue
+        if len(value) == 1 and isinstance(value[0], bool):
+            if value[0] is True:
+                policy_parts[key] = ""
+            continue
         if NONCE in value:
             if nonce:
                 value = [f"'nonce-{nonce}'" if v == NONCE else v for v in value]
@@ -130,6 +133,7 @@ def build_policy(
                 # Strip the `NONCE` sentinel value if no nonce is provided.
                 value = [v for v in value if v != NONCE]
 
+        value = list(dict.fromkeys(value))  # Deduplicate
         policy_parts[key] = " ".join(value)
 
     if report_uri:


### PR DESCRIPTION
- Fixes several exceptions that'd be thrown when trying to use Python sets as config values, rather than tuples or lists. 
- Removes duplicate values from directives when building the full CSP header.
