### PR TITLE
Fix #249: Add `EXCLUDE_URL_PREFIXES` check

### DIFF
--- a/csp/apps.py
+++ b/csp/apps.py
@@ -1,11 +1,7 @@
 from django.apps import AppConfig
-from django.core import checks
 
-from csp.checks import check_django_csp_lt_4_0
+from csp.checks import *  # noqa: F403 (here to register the checks)
 
 
 class CspConfig(AppConfig):
     name = "csp"
-
-    def ready(self) -> None:
-        checks.register(check_django_csp_lt_4_0, checks.Tags.security)

--- a/csp/tests/test_checks.py
+++ b/csp/tests/test_checks.py
@@ -1,6 +1,6 @@
 from django.test.utils import override_settings
 
-from csp.checks import check_django_csp_lt_4_0, migrate_settings
+from csp.checks import check_django_csp_lt_4_0, check_exclude_url_prefixes_is_not_string, migrate_settings
 from csp.constants import NONCE
 
 
@@ -50,3 +50,25 @@ def test_check_django_csp_lt_4_0() -> None:
 
 def test_check_django_csp_lt_4_0_no_config() -> None:
     assert check_django_csp_lt_4_0(None) == []
+
+
+@override_settings(
+    CONTENT_SECURITY_POLICY={"EXCLUDE_URL_PREFIXES": "/admin/"},
+)
+def test_check_exclude_url_prefixes_is_not_string() -> None:
+    errors = check_exclude_url_prefixes_is_not_string(None)
+    assert len(errors) == 1
+    error = errors[0]
+    assert error.id == "csp.E002"
+    assert error.msg == "EXCLUDE_URL_PREFIXES in CONTENT_SECURITY_POLICY settings must be a list or tuple."
+
+
+@override_settings(
+    CONTENT_SECURITY_POLICY_REPORT_ONLY={"EXCLUDE_URL_PREFIXES": "/admin/"},
+)
+def test_check_exclude_url_prefixes_ro_is_not_string() -> None:
+    errors = check_exclude_url_prefixes_is_not_string(None)
+    assert len(errors) == 1
+    error = errors[0]
+    assert error.id == "csp.E002"
+    assert error.msg == "EXCLUDE_URL_PREFIXES in CONTENT_SECURITY_POLICY_REPORT_ONLY settings must be a list or tuple."


### PR DESCRIPTION
Check that EXCLUDE_URL_PREFIXES in settings is not a string.

If it is a string it can lead to a security issue where the string is treated as a list of characters, resulting in '/' matching all paths excluding the CSP header from all responses.