### PR TITLE
docs: Note that reporting percentage needs rate limiting middleware

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Django-CSP"
-copyright = "2016-2024 Mozilla"
+copyright = "2016-%Y Mozilla"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -114,6 +114,11 @@ policy.
     number of CSP violation reports made to your ``report-uri``. A **float** between 0.0 and 100.0
     (0.0 = no reports at all, 100.0 = always report).  Ignored if ``report-uri`` isn't set.
 
+    .. note::
+       To allow rate limiting, ``csp.contrib.rate_limiting.RateLimitedCSPMiddleware`` must be used
+       instead of ``csp.middleware.CSPMiddleware``.
+       See :ref:`violation reporting <reports-chapter>` for more details.
+
 ``DIRECTIVES``
     A dictionary of policy directives. Each key in the dictionary is a directive and the value is a
     list of sources for that directive. The following is a list of all the directives that can be

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,5 @@
-.. Django-CSP documentation master file, created by
-   sphinx-quickstart on Wed Oct 31 13:02:27 2012.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. Django-CSP documentation home.
+   It should contain at least the root `toctree` directive.
 
 ==========
 django-csp
@@ -27,14 +25,6 @@ Contents:
    trusted_types
    reports
    contributing
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
 
 
 .. _Content-Security-Policy: http://www.w3.org/TR/CSP/


### PR DESCRIPTION
Resolves #232

(also removes some empty links from toc boilerplate & updates copyright to strftime placeholder)

Preview: https://janbrasna.github.io/django-csp/configuration.html#policy-settings