### PR TITLE
Allow reading nonce if it was included in header

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -146,7 +146,7 @@ class CSPMiddlewareAlwaysGenerateNonce(CSPMiddleware):
     This is useful when a later process needs a nonce, whether or not the wrapped
     request uses a nonce. One example is django-debug-toolbar (DDT). The DDT
     middleware needs to be high in the MIDDLEWARE list, so it can inject its
-    HTML, CSS, and JS describing the request generation. DDT users can use
+    HTML, CSS, and JS describing the response generation. DDT users can use
     this middleware instead of CSPMiddleware.
     """
 

--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -45,6 +45,8 @@ class CSPMiddleware(MiddlewareMixin):
     Can be customised by subclassing and extending the get_policy_parts method.
     """
 
+    always_generate_nonce = False
+
     def _make_nonce(self, request: HttpRequest) -> str:
         # Ensure that any subsequent calls to request.csp_nonce return the same value
         stored_nonce = getattr(request, "_csp_nonce", None)
@@ -63,6 +65,8 @@ class CSPMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> None:
         nonce = partial(self._make_nonce, request)
         setattr(request, "csp_nonce", SimpleLazyObject(nonce))
+        if self.always_generate_nonce:
+            self._make_nonce(request)
 
     def process_response(self, request: HttpRequest, response: HttpResponseBase) -> HttpResponseBase:
         # Check for debug view
@@ -133,3 +137,17 @@ class CSPMiddleware(MiddlewareMixin):
         nonce = getattr(request, "_csp_nonce", None)
 
         return PolicyParts(config, update, replace, nonce)
+
+
+class CSPMiddlewareAlwaysGenerateNonce(CSPMiddleware):
+    """
+    A middleware variant that always generates a nonce.
+
+    This is useful when a later process needs a nonce, whether or not the wrapped
+    request uses a nonce. One example is django-debug-toolbar (DDT). The DDT
+    middleware needs to be high in the MIDDLEWARE list, so it can inject its
+    HTML, CSS, and JS describing the request generation. DDT users can use
+    this middleware instead of CSPMiddleware.
+    """
+
+    always_generate_nonce = True

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,6 +31,11 @@ to ``MIDDLEWARE``, like so:
         # ...
     )
 
-Note: Middleware order does not matter unless you have other middleware modifying the CSP header.
+.. Note::
+
+   Middleware order does not matter unless you have other middleware modifying
+   the CSP header, or requires CSP features like a nonce. See
+   :ref:`Using the generated CSP nonce` for further advice on middleware order.
+
 
 That should do it! Go on to :ref:`configuring CSP <configuration-chapter>`.


### PR DESCRIPTION
If the nonce was generated before the CSP headers were set, then allow reading it with ``request.csp_nonce``.

If the CSP headers were set with no nonce, then continue raising ``CSPNonceError`` when reading it as a string. If read as a boolean (`if request.csp_nonce`), then return `False`.

This will allow other middleware like [django-debug-toolbar](https://github.com/django-commons/django-debug-toolbar) to alter the response after the CSP middleware runs, fixing #268.