### PR TITLE
Prepare for 4.0b5 Release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       # Run the formatter
       - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.5.0
+    rev: v2.5.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/adamchainz/blacken-docs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,22 @@
 CHANGES
 =======
 
+4.0b5
+=====
+BACKWARDS INCOMPATIBLE change:
+
+- `request.csp_nonce` is now Falsy (`bool(request.csp_nonce)`) until it is read as a
+  string (for example, used in a template, or `str(request.csp_nonce)`). Previously,
+  it always tested as `True`, and testing generated the nonce.
+  ([#270](https://github.com/mozilla/django-csp/pull/270))
+
+Other changes:
+
+- Upgrade ReadTheDocs environment ([#262](https://github.com/mozilla/django-csp/pull/262))
+- Allow reading the nonce after response if it was included in the header. Add
+  ``CSPMiddlewareAlwaysGenerateNonce`` to always generate a nonce.
+  ([#269](https://github.com/mozilla/django-csp/pull/262))
+
 4.0b4
 =====
 - Fix missing packaging dependency ([#266](https://github.com/mozilla/django-csp/pull/266))
@@ -30,12 +46,14 @@ CHANGES
 4.0b1
 =====
 BACKWARDS INCOMPATIBLE changes:
+
 - Move to dict-based configuration which allows for setting policies for both enforced and
   report-only. See the migration guide in the docs for migrating your settings.
 - Switch from specifying which directives should contain the nonce as a separate list, and instead
   use a sentinel `NONCE` in the directive itself.
 
 Other changes:
+
 - Add pyproject-fmt to pre-commit, and update pre-commit versions
 - Fixes #36: Add support for enforced and report-only policies simultaneously
 - Drop support for Django <=3.2, end of extended support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=61.2",
-]
+requires = [ "setuptools>=61.2" ]
 
 [project]
 name = "django-csp"
@@ -13,9 +11,7 @@ license = { text = "BSD" }
 maintainers = [
   { name = "Mozilla MEAO team", email = "meao-backend@mozilla.com" },
 ]
-authors = [
-  { name = "James Socol", email = "me@jamessocol.com" },
-]
+authors = [ { name = "James Socol", email = "me@jamessocol.com" } ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
@@ -38,10 +34,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-  "django>=4.2",
-  "packaging",
-]
+dependencies = [ "django>=4.2", "packaging" ]
 optional-dependencies.dev = [
   "django-stubs[compatible-mypy]",
   "jinja2>=2.9.6",
@@ -57,9 +50,7 @@ optional-dependencies.dev = [
   "tox-gh-actions",
   "types-setuptools",
 ]
-optional-dependencies.jinja2 = [
-  "jinja2>=2.9.6",
-]
+optional-dependencies.jinja2 = [ "jinja2>=2.9.6" ]
 optional-dependencies.tests = [
   "jinja2>=2.9.6",
   "pytest",
@@ -92,11 +83,7 @@ find = { namespaces = false }
 target-version = "py39"
 line-length = 150
 indent-width = 4
-extend-exclude = [
-  "build",
-  "dist",
-  "docs",
-]
+extend-exclude = [ "build", "dist", "docs" ]
 
 # Set what ruff should check for.
 # See https://docs.astral.sh//ruff/rules/ for a list of rules.
@@ -115,9 +102,7 @@ lint.select = [
 ]
 # Allow unused variables when underscore-prefixed.
 lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-lint.isort.known-first-party = [
-  "csp",
-]
+lint.isort.known-first-party = [ "csp" ]
 lint.isort.section-order = [
   "future",
   "standard-library",
@@ -126,21 +111,15 @@ lint.isort.section-order = [
   "first-party",
   "local-folder",
 ]
-lint.isort.sections.django = [
-  "django",
-]
+lint.isort.sections.django = [ "django" ]
 
 [tool.pytest.ini_options]
 addopts = "-vs --tb=short --ruff --ruff-format"
 DJANGO_SETTINGS_MODULE = "csp.tests.settings"
 
 [tool.mypy]
-plugins = [
-  "mypy_django_plugin.main",
-]
-exclude = [
-  '^build/lib',
-]
+plugins = [ "mypy_django_plugin.main" ]
+exclude = [ '^build/lib' ]
 strict = true
 
 [tool.django-stubs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61.2" ]
 
 [project]
 name = "django-csp"
-version = "4.0b4"
+version = "4.0b5"
 description = "Django Content Security Policy support."
 readme = "README.rst"
 license = { text = "BSD" }


### PR DESCRIPTION
* Reformat with `pyproject-fmt v2.5.0`, and update to latest `v2.5.1`
* Add release notes, mark `request.csp_nonce` truthiness as backwards-incompatible change
* Bump version to `4.0b5`