### PR TITLE
Fix CSPMiddlewareAlwaysGenerateNonce

### DIFF
--- a/csp/middleware.py
+++ b/csp/middleware.py
@@ -72,7 +72,7 @@ class CSPMiddleware(MiddlewareMixin):
         nonce = partial(self._make_nonce, request)
         setattr(request, "csp_nonce", CheckableLazyObject(nonce))
         if self.always_generate_nonce:
-            self._make_nonce(request)
+            str(getattr(request, "csp_nonce"))
 
     def process_response(self, request: HttpRequest, response: HttpResponseBase) -> HttpResponseBase:
         # Check for debug view

--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -297,10 +297,11 @@ def test_csp_always_nonce_middleware_has_nonce() -> None:
     request = rf.get("/")
     mw_agn = CSPMiddlewareAlwaysGenerateNonce(response())
     mw_agn.process_request(request)
+    nonce = getattr(request, "csp_nonce")
+    assert bool(nonce) is True
     resp = HttpResponse()
     mw_agn.process_response(request, resp)
-    nonce = str(getattr(request, "csp_nonce"))
-    assert nonce in resp[HEADER]
+    assert str(nonce) in resp[HEADER]
 
 
 def test_csp_always_nonce_middleware_nonce_regenerated_on_new_request() -> None:
@@ -326,7 +327,8 @@ def test_csp_always_nonce_middleware_access_after_middleware_is_ok() -> None:
     request = rf.get("/")
     mw_agn = CSPMiddlewareAlwaysGenerateNonce(response())
     mw_agn.process_request(request)
-    nonce = str(getattr(request, "csp_nonce"))
+    nonce = getattr(request, "csp_nonce")
+    assert bool(nonce) is True
     mw_agn.process_response(request, HttpResponse())
-    assert bool(getattr(request, "csp_nonce", False)) is True
+    assert bool(nonce) is True
     assert str(getattr(request, "csp_nonce")) == nonce


### PR DESCRIPTION
Further fix for issue #268 - `CSPMiddlewareAlwaysGenerateNonce` needs to read `self.csp_nonce` as a string in order to properly initialize the lazy object.