### PR TITLE
Prepare for 4.0b6 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+4.0b6
+=====
+- Fix ``CSPMiddlewareAlwaysGenerateNonce`` to always generate the nonce.
+  ([#272](https://github.com/mozilla/django-csp/pull/272))
+
 4.0b5
 =====
 BACKWARDS INCOMPATIBLE change:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61.2" ]
 
 [project]
 name = "django-csp"
-version = "4.0b5"
+version = "4.0b6"
 description = "Django Content Security Policy support."
 readme = "README.rst"
 license = { text = "BSD" }


### PR DESCRIPTION
4.0b6 contains a fix for the ``CSPMiddlewareAlwaysGenerateNonce`` added in 4.0b5.