### PR TITLE
Remove `CSPMiddlewareAlwaysGenerateNonce`

### DIFF
--- a/csp/tests/test_middleware.py
+++ b/csp/tests/test_middleware.py
@@ -11,11 +11,7 @@ import pytest
 
 from csp.constants import HEADER, HEADER_REPORT_ONLY, SELF
 from csp.exceptions import CSPNonceError
-from csp.middleware import (
-    CheckableLazyObject,
-    CSPMiddleware,
-    CSPMiddlewareAlwaysGenerateNonce,
-)
+from csp.middleware import CheckableLazyObject, CSPMiddleware
 from csp.tests.utils import response
 
 mw = CSPMiddleware(response())
@@ -290,45 +286,4 @@ def test_set_nonce_access_after_middleware_is_ok() -> None:
     nonce = str(getattr(request, "csp_nonce"))
     mw.process_response(request, HttpResponse())
     assert bool(getattr(request, "csp_nonce", False)) is True
-    assert str(getattr(request, "csp_nonce")) == nonce
-
-
-def test_csp_always_nonce_middleware_has_nonce() -> None:
-    request = rf.get("/")
-    mw_agn = CSPMiddlewareAlwaysGenerateNonce(response())
-    mw_agn.process_request(request)
-    nonce = getattr(request, "csp_nonce")
-    assert bool(nonce) is True
-    resp = HttpResponse()
-    mw_agn.process_response(request, resp)
-    assert str(nonce) in resp[HEADER]
-
-
-def test_csp_always_nonce_middleware_nonce_regenerated_on_new_request() -> None:
-    mw_agn = CSPMiddlewareAlwaysGenerateNonce(response())
-    request1 = rf.get("/")
-    request2 = rf.get("/")
-    mw_agn.process_request(request1)
-    mw_agn.process_request(request2)
-    nonce1 = str(getattr(request1, "csp_nonce"))
-    nonce2 = str(getattr(request2, "csp_nonce"))
-    assert nonce1 != nonce2
-
-    response1 = HttpResponse()
-    response2 = HttpResponse()
-    mw_agn.process_response(request1, response1)
-    mw_agn.process_response(request2, response2)
-    assert nonce1 not in response2[HEADER]
-    assert nonce2 not in response1[HEADER]
-
-
-def test_csp_always_nonce_middleware_access_after_middleware_is_ok() -> None:
-    # Test accessing a set nonce after the response has been processed is OK.
-    request = rf.get("/")
-    mw_agn = CSPMiddlewareAlwaysGenerateNonce(response())
-    mw_agn.process_request(request)
-    nonce = getattr(request, "csp_nonce")
-    assert bool(nonce) is True
-    mw_agn.process_response(request, HttpResponse())
-    assert bool(nonce) is True
     assert str(getattr(request, "csp_nonce")) == nonce

--- a/docs/nonce.rst
+++ b/docs/nonce.rst
@@ -68,8 +68,6 @@ If other middleware or a later process needs to access ``request.csp_nonce``, th
 
 * The middleware can be placed after ``csp.middleware.CSPMiddleware`` in the ``MIDDLEWARE`` setting.
   This ensures that the middleware generates the nonce before ``CSPMiddleware`` writes the CSP header.
-* Use the alternate ``csp.middleware.CSPMiddlewareAlwaysGenerateNonce`` middleware, which always
-  generates a nonce and includes it in the CSP header.
 * Add a later middleware that accesses the nonce. For example, this function:
 
 .. code-block:: python


### PR DESCRIPTION
The middleware was originally added to support Django Debug Toolbar by forcing nonce headers even when not used in content. This is no longer needed since Debug Toolbar now handles this properly with `CheckableLazyObject`.

It is recommended to only include a nonce in the header if it is used in the content and as such this removal helps the user follow good security practices.
