### PR TITLE
Use tox defaults & derive matrix strategy dynamically in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,44 +1,56 @@
-name: "CI" # Note that this name appears in the README's badge
+name: "CI" # This name also appears on the badge in README and PyPI
+
 on:
   push:
     branches:
       - main
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
   release:
     types: [published]
-jobs:
-  run-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-            - '3.9'
-            - '3.10'
-            - '3.11'
-            - '3.12'
-            - '3.13'
-            - 'pypy-3.9'
-            - 'pypy-3.10'
 
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+    outputs:
+      envlist: ${{ steps.tox.outputs.envlist }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+      - name: Install tox and plugins
+        run: pip install tox tox-gh-matrix
+      - name: Get tox matrix
+        id: tox
+        run: tox --gh-matrix
+
+  test:
+    name: Test ${{ matrix.tox.name }}
+    runs-on: ubuntu-latest
+    needs: tox
+    strategy:
+      fail-fast: false
+      matrix:
+        tox: ${{ fromJSON(needs.tox.outputs.envlist) }}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.tox.python.version }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+        python-version: ${{ matrix.tox.python.spec }}
+        cache: pip
+    - name: Install tox
+      run: pip install tox
+    - name: Test ${{ matrix.tox.name }}
+      run: tox -e ${{ matrix.tox.name }}
 
   release:
     name: Release django-csp
     if: github.event_name == 'release' && github.event.action == 'published'
     needs:
-      - run-tests
+      - test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   tox:
+    name: Configure test matrix
     runs-on: ubuntu-latest
     outputs:
       envlist: ${{ steps.tox.outputs.envlist }}
@@ -25,6 +26,8 @@ jobs:
       - name: Get tox matrix
         id: tox
         run: tox --gh-matrix
+      - name: Log saved outputs
+        run: echo ${{ steps.tox.outputs.envlist }}
 
   test:
     name: Test ${{ matrix.tox.name }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
 isolated_build = True
 envlist =
-    {3.12,3.13}-djmain
-    {3.10,3.11,3.12,3.13,pypy310}-dj{5.0,5.1,5.2}
-    {3.9,3.10,3.11,3.12,3.13,pypy39,pypy310}-dj4.2
-    {3.9,3.10,3.11,3.12,3.13,pypy39,pypy310}-types
+    py{312,313}-djmain
+    py{310,311,312,313,py310}-dj5{1,2}
+    py{39,310,311,312,313,py39,py310}-dj42
+    py{39,310,311,312,313,py39,py310}-types
 
 
 # Don't run coverage when testing with pypy:
 # see https://github.com/nedbat/coveragepy/issues/1382
-[testenv:pypy{39,310}-dj4.2,pypy310-dj{5.0,5.1,5.2}]
+[testenv:pypy{39,310}-dj42,pypy310-dj5{1,2}]
 commands =
     pytest {toxinidir}/csp
 
-[testenv:{3.9,3.10,3.11,3.12,3.13,pypy39,pypy310}-types]
+[testenv:py{39,310,311,312,313,py39,py310}-types]
 commands =
     mypy --cache-dir {temp_dir}/.mypy_cache {toxinidir}/csp
 
@@ -26,32 +26,9 @@ setenv =
 commands =
     pytest --cov={toxinidir}/csp  {toxinidir}/csp
 
-basepython =
-    3.9: python3.9
-    3.10: python3.10
-    3.11: python3.11
-    3.12: python3.12
-    3.13: python3.13
-    pypy39: pypy3.9
-    pypy310: pypy3.10
-
 deps =
     pytest
-    dj4.2: Django>=4.2,<4.3
-    dj5.0: Django>=5.0.1,<5.1
-    dj5.1: Django>=5.1,<5.2
-    dj5.2: Django>=5.2a1,<5.3
+    dj42: Django>=4.2,<4.3
+    dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz
-
-
-[gh-actions]
-# Running tox in GHA without redefining it all in a GHA matrix:
-# https://github.com/ymyzk/tox-gh-actions
-python =
-    3.9: 3.9
-    3.10: 3.10
-    3.11: 3.11
-    3.12: 3.12
-    3.13: 3.13
-    pypy-3.9: pypy39
-    pypy-3.10: pypy310


### PR DESCRIPTION
Tox recognizes some implicit formats of factors naming by default without having to repeat the envs all over the configs and map them explicitly. Combined with some dynamic matrix setup, this makes all the bits involved a little more DRY.

Aside from removing points of failure when edits do not keep all the files in sync, the main benefit is running all the envs individually, in parallel. It comes at a cost of more minutes consumed in total due to runner overhead/setup, however allows finishing the pipeline as a whole a lot faster.

_Example runs: [janbrasna/django-csp: runs/15198630422](https://github.com/janbrasna/django-csp/actions/runs/15198630422)
Logged matrix: [janbrasna/django-csp: runs/15198743219/job/42748716149](https://github.com/janbrasna/django-csp/actions/runs/15198743219/job/42748716149)_