### PR TITLE
Fix too strict typing of view functions in decorators

### DIFF
--- a/csp/decorators.py
+++ b/csp/decorators.py
@@ -4,10 +4,10 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
-    from django.http import HttpRequest, HttpResponseBase
+    from django.http import HttpResponseBase
 
     # A generic Django view function
-    _VIEW_T = Callable[[HttpRequest], HttpResponseBase]
+    _VIEW_T = Callable[..., HttpResponseBase]
     _VIEW_DECORATOR_T = Callable[[_VIEW_T], _VIEW_T]
 
 


### PR DESCRIPTION
View functions can have additional parameters if the URL has parameters.
Currently these are not allowed by the typing even though the code
itself handles them just fine.

Expand the view type to match what django-stubs is using e.g. here:
https://github.com/typeddjango/django-stubs/blob/fb310b1b0b40c666c156f0943804f3791ff48f95/django-stubs/urls/conf.pyi#L18
