### PR TITLE
Test on Django 6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 isolated_build = True
 envlist =
     {3.12,3.13}-djmain
+    {3.12,3.13}-dj{6.0}
     {3.10,3.11,3.12,3.13,pypy310}-dj{5.0,5.1,5.2}
     {3.9,3.10,3.11,3.12,3.13,pypy39,pypy310}-dj4.2
     {3.9,3.10,3.11,3.12,3.13,pypy39,pypy310}-types
@@ -41,6 +42,7 @@ deps =
     dj5.0: Django>=5.0.1,<5.1
     dj5.1: Django>=5.1,<5.2
     dj5.2: Django>=5.2a1,<5.3
+    dj6.0: Django>=6.0a1,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 


### PR DESCRIPTION
Now in beta: https://www.djangoproject.com/weblog/2025/oct/22/django-60-beta-released/

Since it has built-in CSP support, maybe this should be the last version that django-csp supports?